### PR TITLE
BEAD-78 Updated unit tests

### DIFF
--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -36,20 +36,20 @@ class ApplicationTest extends TestCase
         $replacement = (object) ["fox" => "bax",];
         $this->m_app->bindService("foo", $original);
 
-        $this->assertSame($original, $this->m_app->service("foo"));
+        self::assertSame($original, $this->m_app->service("foo"));
         $acutal = $this->m_app->replaceService("foo", $replacement);
-        $this->assertSame($original, $acutal);
-        $this->assertSame($replacement, $this->m_app->service("foo"));
+        self::assertSame($original, $acutal);
+        self::assertSame($replacement, $this->m_app->service("foo"));
     }
 
     public function testBindService(): void
     {
         $original = (object) ["foo" => "bar",];
         $replacement = (object) ["fox" => "bax",];
-        $this->assertFalse($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("foo"));
         $this->m_app->bindService("foo", $original);
-        $this->assertTrue($this->m_app->serviceIsBound("foo"));
-        $this->assertSame($original, $this->m_app->service("foo"));
+        self::assertTrue($this->m_app->serviceIsBound("foo"));
+        self::assertSame($original, $this->m_app->service("foo"));
 
         $this->expectException(ServiceAlreadyBoundException::class);
         $this->m_app->bindService("foo", $replacement);
@@ -58,36 +58,36 @@ class ApplicationTest extends TestCase
     public function testService(): void
     {
         $original = (object) ["foo" => "bar",];
-        $this->assertFalse($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("foo"));
         $this->m_app->bindService("foo", $original);
-        $this->assertTrue($this->m_app->serviceIsBound("foo"));
-        $this->assertSame($original, $this->m_app->service("foo"));
+        self::assertTrue($this->m_app->serviceIsBound("foo"));
+        self::assertSame($original, $this->m_app->service("foo"));
     }
 
     public function testServiceIsBound(): void
     {
         $original = (object) ["foo" => "bar",];
-        $this->assertFalse($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("foo"));
         $this->m_app->bindService("foo", $original);
-        $this->assertTrue($this->m_app->serviceIsBound("foo"));
-        $this->assertFalse($this->m_app->serviceIsBound("fox"));
+        self::assertTrue($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("fox"));
     }
 
     public function testGet(): void
     {
         $original = (object) ["foo" => "bar",];
-        $this->assertFalse($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("foo"));
         $this->m_app->bindService("foo", $original);
-        $this->assertTrue($this->m_app->serviceIsBound("foo"));
-        $this->assertSame($original, $this->m_app->get("foo"));
+        self::assertTrue($this->m_app->serviceIsBound("foo"));
+        self::assertSame($original, $this->m_app->get("foo"));
     }
 
     public function testHas(): void
     {
         $original = (object) ["foo" => "bar",];
-        $this->assertFalse($this->m_app->serviceIsBound("foo"));
+        self::assertFalse($this->m_app->serviceIsBound("foo"));
         $this->m_app->bindService("foo", $original);
-        $this->assertTrue($this->m_app->has("foo"));
-        $this->assertFalse($this->m_app->has("fox"));
+        self::assertTrue($this->m_app->has("foo"));
+        self::assertFalse($this->m_app->has("fox"));
     }
 }

--- a/test/Concurrent/SharedMemoryTest.php
+++ b/test/Concurrent/SharedMemoryTest.php
@@ -65,7 +65,7 @@ class SharedMemoryTest extends TestCase
     {
         $memory = SharedMemory::create(10, 0x80808080);
         $this->m_memories[] = $memory;
-        $this->assertEquals(0x80808080, $memory->id());
+        self::assertEquals(0x80808080, $memory->id());
     }
 
     public function testCreateThrows(): void
@@ -93,15 +93,15 @@ class SharedMemoryTest extends TestCase
 
         $memory = SharedMemory::create(10);
         $this->m_memories[] = $memory;
-        $this->assertIsInt($memory->id());
-        $this->assertEquals($newId, $memory->id());
+        self::assertIsInt($memory->id());
+        self::assertEquals($newId, $memory->id());
     }
 
     public function testOpen(): void
     {
         $memory = SharedMemory::open(self::SharedMemoryTestId);
-        $this->assertInstanceOf(SharedMemory::class, $memory);
-        $this->assertEquals(self::SharedMemoryTestId, $memory->id());
+        self::assertInstanceOf(SharedMemory::class, $memory);
+        self::assertEquals(self::SharedMemoryTestId, $memory->id());
     }
 
     public function testOpenThrows(): void
@@ -114,7 +114,7 @@ class SharedMemoryTest extends TestCase
 
     public function testId(): void
     {
-        $this->assertEquals(self::SharedMemoryTestId, $this->m_memory->id());
+        self::assertEquals(self::SharedMemoryTestId, $this->m_memory->id());
     }
 
     public function testIdWithClosed(): void
@@ -131,19 +131,19 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertEquals(0, $memory->id());
+        self::assertEquals(0, $memory->id());
     }
 
     public function testIdWithDeleted(): void
     {
         $memory = SharedMemory::create(100, 0x80808080);
         $memory->delete();
-        $this->assertEquals(0, $memory->id());
+        self::assertEquals(0, $memory->id());
     }
 
     public function testSize(): void
     {
-        $this->assertEquals(self::SharedMemoryTestSize, $this->m_memory->size());
+        self::assertEquals(self::SharedMemoryTestSize, $this->m_memory->size());
     }
 
     public function testSizeWithClosed(): void
@@ -160,19 +160,19 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertEquals(0, $memory->size());
+        self::assertEquals(0, $memory->size());
     }
 
     public function testSizeWithDeleted(): void
     {
         $memory = SharedMemory::create(100, 0x80808080);
         $memory->delete();
-        $this->assertEquals(0, $memory->size());
+        self::assertEquals(0, $memory->size());
     }
 
     public function testIsOpen(): void
     {
-        $this->assertTrue($this->m_memory->isOpen());
+        self::assertTrue($this->m_memory->isOpen());
     }
 
     public function testIsOpenWithClosed(): void
@@ -189,19 +189,19 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertFalse($memory->isOpen());
+        self::assertFalse($memory->isOpen());
     }
 
     public function tesIsOpenWithDeleted(): void
     {
         $memory = SharedMemory::create(100, 0x80808080);
         $memory->delete();
-        $this->assertFalse($memory->isOpen());
+        self::assertFalse($memory->isOpen());
     }
 
     public function testIsReadable(): void
     {
-        $this->assertTrue($this->m_memory->isReadable());
+        self::assertTrue($this->m_memory->isReadable());
     }
 
     public function testIsReadableWithClosed(): void
@@ -218,20 +218,20 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertFalse($memory->isReadable());
+        self::assertFalse($memory->isReadable());
     }
 
     public function tesIsReadableWithDeleted(): void
     {
         $memory = SharedMemory::create(100, 0x80808080);
         $memory->delete();
-        $this->assertFalse($memory->isReadable());
+        self::assertFalse($memory->isReadable());
     }
 
     public function testIsWritable(): void
     {
         $memory = SharedMemory::open(self::SharedMemoryTestId, SharedMemory::ModeReadWrite);
-        $this->assertTrue($memory->isWritable());
+        self::assertTrue($memory->isWritable());
     }
 
     public function testIsWritableWithClosed(): void
@@ -248,14 +248,14 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertFalse($memory->isWritable());
+        self::assertFalse($memory->isWritable());
     }
 
     public function tesIsWritableWithDeleted(): void
     {
         $memory = SharedMemory::create(100, 0x80808080);
         $memory->delete();
-        $this->assertFalse($memory->isWritable());
+        self::assertFalse($memory->isWritable());
     }
 
     public function testClose(): void
@@ -272,7 +272,7 @@ class SharedMemoryTest extends TestCase
         });
 
         $memory->close();
-        $this->assertFalse($memory->isOpen());
+        self::assertFalse($memory->isOpen());
     }
 
     public function testDelete(): void
@@ -281,7 +281,7 @@ class SharedMemoryTest extends TestCase
         $memory = SharedMemory::create(10, $id);
         $this->m_memories[] = $memory;
         $memory->delete();
-        $this->assertFalse($memory->isOpen());
+        self::assertFalse($memory->isOpen());
 
         // prove that the shared memory has actually been deleted, not just closed
         $this->expectException(SharedMemoryException::class);
@@ -295,10 +295,10 @@ class SharedMemoryTest extends TestCase
         $handle = $memory->m_handle;
         $memory->nullify();
         shmop_delete($handle);
-        $this->assertNull($memory->m_handle);
-        $this->assertEquals(0, $memory->id());
-        $this->assertEquals(0, $memory->size());
-        $this->assertEquals(SharedMemory::ModeRead, $memory->m_mode);
+        self::assertNull($memory->m_handle);
+        self::assertEquals(0, $memory->id());
+        self::assertEquals(0, $memory->size());
+        self::assertEquals(SharedMemory::ModeRead, $memory->m_mode);
     }
 
     public function testReadInt64(): void
@@ -307,7 +307,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("q", $value), 0);
         $actual = $this->m_memory->readInt64();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt64WithOffset(): void
@@ -317,7 +317,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("q", $value), $offset);
         $actual = $this->m_memory->readInt64($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt64ThrowsWithClosed(): void
@@ -371,7 +371,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("Q", $value), 0);
         $actual = $this->m_memory->readUInt64();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt64WithOffset(): void
@@ -381,7 +381,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("Q", $value), $offset);
         $actual = $this->m_memory->readUInt64($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt64ThrowsWithClosed(): void
@@ -438,7 +438,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("i", $value), 0);
         $actual = $this->m_memory->readInt32();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt32WithOffset(): void
@@ -448,7 +448,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("i", $value), $offset);
         $actual = $this->m_memory->readInt32($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt32ThrowsWithClosed(): void
@@ -505,7 +505,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("I", $value), 0);
         $actual = $this->m_memory->readUInt32();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt32WithOffset(): void
@@ -515,7 +515,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("I", $value), $offset);
         $actual = $this->m_memory->readUInt32($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt32ThrowsWithClosed(): void
@@ -572,7 +572,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("s", $value), 0);
         $actual = $this->m_memory->readInt16();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt16WithOffset(): void
@@ -582,7 +582,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("s", $value), $offset);
         $actual = $this->m_memory->readInt16($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt16ThrowsWithClosed(): void
@@ -639,7 +639,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("S", $value), 0);
         $actual = $this->m_memory->readUInt16();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt16WithOffset(): void
@@ -649,7 +649,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("S", $value), $offset);
         $actual = $this->m_memory->readUInt16($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt16ThrowsWithClosed(): void
@@ -706,7 +706,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("c", $value), 0);
         $actual = $this->m_memory->readInt8();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt8WithOffset(): void
@@ -716,7 +716,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("c", $value), $offset);
         $actual = $this->m_memory->readInt8($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadInt8ThrowsWithClosed(): void
@@ -766,7 +766,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("C", $value), 0);
         $actual = $this->m_memory->readUInt8();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt8WithOffset(): void
@@ -776,7 +776,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, pack("C", $value), $offset);
         $actual = $this->m_memory->readUInt8($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadUInt8ThrowsWithClosed(): void
@@ -826,7 +826,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, 0);
         $actual = $this->m_memory->readString(0, strlen($value));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadStringWithOffset(): void
@@ -836,7 +836,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, $offset);
         $actual = $this->m_memory->readString($offset, strlen($value));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadStringWholeBlock(): void
@@ -845,7 +845,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, 0);
         $actual = $this->m_memory->readString();
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadStringWithNegativeOffset(): void
@@ -882,7 +882,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, 0);
         $actual = $this->m_memory->readCString(0);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testReadCStringWithManyNulls(): void
@@ -891,9 +891,9 @@ class SharedMemoryTest extends TestCase
         $expected = "bead-framework";
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, 0);
-        $this->assertEquals($value, $this->m_memory->readString(0, strlen($value)));
+        self::assertEquals($value, $this->m_memory->readString(0, strlen($value)));
         $actual = $this->m_memory->readCString(0);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testReadCStringWithOffset(): void
@@ -904,7 +904,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $value, 0);
         $actual = $this->m_memory->readCString($offset);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testReadCStringWithNegativeOffset(): void
@@ -941,7 +941,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $json, 0);
         $actual = $this->m_memory->readJson(0, strlen($json));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadJsonWithOffset(): void
@@ -952,7 +952,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, $json, $offset);
         $actual = $this->m_memory->readJson($offset, strlen($json));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testReadJsonWithTruncatedSize(): void
@@ -998,7 +998,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, serialize($value), 0);
         $actual = $this->m_memory->unserialize(0);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testUnserializeWithOffset(): void
@@ -1008,7 +1008,7 @@ class SharedMemoryTest extends TestCase
         $memory = new XRay($this->m_memory);
         shmop_write($memory->m_handle, serialize($value), $offset);
         $actual = $this->m_memory->unserialize($offset);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testUnserializeWithTruncatedSize(): void
@@ -1054,7 +1054,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt64($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("q", shmop_read($memory->m_handle, 0,8))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt64WithOffset(): void
@@ -1064,7 +1064,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt64($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("q", shmop_read($memory->m_handle, $offset,8))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt64ThrowsWithClosed(): void
@@ -1120,7 +1120,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt64($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("Q", shmop_read($memory->m_handle, 0,8))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt64WithOffset(): void
@@ -1130,7 +1130,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt64($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("Q", shmop_read($memory->m_handle, $offset,8))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt64ThrowsWithClosed(): void
@@ -1186,7 +1186,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt32($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("i", shmop_read($memory->m_handle, 0,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt32WithOffset(): void
@@ -1196,7 +1196,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt32($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("i", shmop_read($memory->m_handle, $offset,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt32ThrowsWithClosed(): void
@@ -1252,7 +1252,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt32($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("I", shmop_read($memory->m_handle, 0,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt32WithOffset(): void
@@ -1262,7 +1262,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt32($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("I", shmop_read($memory->m_handle, $offset,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt32ThrowsWithClosed(): void
@@ -1318,7 +1318,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt16($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("s", shmop_read($memory->m_handle, 0,2))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt16WithOffset(): void
@@ -1328,7 +1328,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt16($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("s", shmop_read($memory->m_handle, $offset,2))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt16ThrowsWithClosed(): void
@@ -1384,7 +1384,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt16($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("S", shmop_read($memory->m_handle, 0,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt16WithOffset(): void
@@ -1394,7 +1394,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt16($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("S", shmop_read($memory->m_handle, $offset,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt16ThrowsWithClosed(): void
@@ -1450,7 +1450,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt8($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("c", shmop_read($memory->m_handle, 0,2))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt8WithOffset(): void
@@ -1460,7 +1460,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeInt8($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("c", shmop_read($memory->m_handle, $offset,2))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteInt8ThrowsWithClosed(): void
@@ -1516,7 +1516,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt8($value);
         $memory = new XRay($this->m_memory);
         $actual = unpack("C", shmop_read($memory->m_handle, 0,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt8WithOffset(): void
@@ -1526,7 +1526,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeUInt8($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = unpack("C", shmop_read($memory->m_handle, $offset,4))[1];
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteUInt8ThrowsWithClosed(): void
@@ -1582,7 +1582,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeString($value);
         $memory = new XRay($this->m_memory);
         $actual = shmop_read($memory->m_handle, 0, strlen($value));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteStringWithOffset(): void
@@ -1592,7 +1592,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeString($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = shmop_read($memory->m_handle, $offset, strlen($value));
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteStringWholeBlock(): void
@@ -1601,7 +1601,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeString($value);
         $memory = new XRay($this->m_memory);
         $actual = shmop_read($memory->m_handle, 0, self::SharedMemoryTestSize);
-        $this->assertEquals($value, $actual);
+        self::assertEquals($value, $actual);
     }
 
     public function testWriteStringWithNegativeOffset(): void
@@ -1638,7 +1638,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeCString($value);
         $memory = new XRay($this->m_memory);
         $actual = shmop_read($memory->m_handle, 0, strlen($expected));
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testWriteCStringWithOffset(): void
@@ -1649,7 +1649,7 @@ class SharedMemoryTest extends TestCase
         $this->m_memory->writeCString($value, $offset);
         $memory = new XRay($this->m_memory);
         $actual = shmop_read($memory->m_handle, $offset, strlen($expected));
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     public function testWriteCStringWithNegativeOffset(): void
@@ -1684,8 +1684,8 @@ class SharedMemoryTest extends TestCase
         $value = ["bead" => "framework",];
         $actual = $this->m_memory->writeJson($value);
         $expected = json_encode($value);
-        $this->assertEquals(strlen($expected), $actual);
-        $this->assertEquals($expected, $this->m_memory->readString(0, strlen($expected)));
+        self::assertEquals(strlen($expected), $actual);
+        self::assertEquals($expected, $this->m_memory->readString(0, strlen($expected)));
     }
 
     public function testWriteJsonWithOffset(): void
@@ -1694,8 +1694,8 @@ class SharedMemoryTest extends TestCase
         $offset = 5;
         $actual = $this->m_memory->writeJson($value, $offset);
         $expected = json_encode($value);
-        $this->assertEquals(strlen($expected), $actual);
-        $this->assertEquals($expected, $this->m_memory->readString($offset, strlen($expected)));
+        self::assertEquals(strlen($expected), $actual);
+        self::assertEquals($expected, $this->m_memory->readString($offset, strlen($expected)));
     }
 
     public function testWriteJsonWithNegativeOffset(): void
@@ -1730,8 +1730,8 @@ class SharedMemoryTest extends TestCase
         $value = [1, 2, 3,];
         $actual = $this->m_memory->serialize($value);
         $expected = serialize($value);
-        $this->assertEquals(strlen($expected), $actual);
-        $this->assertEquals($expected, $this->m_memory->readString(0, strlen($expected)));
+        self::assertEquals(strlen($expected), $actual);
+        self::assertEquals($expected, $this->m_memory->readString(0, strlen($expected)));
     }
 
     public function testSerializeWithOffset(): void
@@ -1740,8 +1740,8 @@ class SharedMemoryTest extends TestCase
         $offset = 5;
         $actual = $this->m_memory->serialize($value, $offset);
         $expected = serialize($value);
-        $this->assertEquals(strlen($expected), $actual);
-        $this->assertEquals($expected, $this->m_memory->readString($offset, strlen($expected)));
+        self::assertEquals(strlen($expected), $actual);
+        self::assertEquals($expected, $this->m_memory->readString($offset, strlen($expected)));
     }
 
     public function testSerializeWithNegativeOffset(): void

--- a/test/Database/ConnectionTest.php
+++ b/test/Database/ConnectionTest.php
@@ -30,7 +30,7 @@ class ConnectionTest extends TestCase
      */
     public function testSqlToDefactoWildcards(string $sql, string $expected): void
     {
-        $this->assertEquals($expected, Connection::sqlToDefactoWildcards($sql));
+        self::assertEquals($expected, Connection::sqlToDefactoWildcards($sql));
     }
 
     public function dataForTestDefactoToSqlWildcards(): iterable
@@ -53,7 +53,7 @@ class ConnectionTest extends TestCase
      */
     public function testDefactoToSqlWildcards(string $defacto, string $expected): void
     {
-        $this->assertEquals($expected, Connection::defactoToSqlWildcards($defacto));
+        self::assertEquals($expected, Connection::defactoToSqlWildcards($defacto));
     }
 
     public function dataForTestEscapeSqlWildcards(): iterable
@@ -74,7 +74,7 @@ class ConnectionTest extends TestCase
      */
     public function testEscapeSqlWildcards(string $sql, string $expected): void
     {
-        $this->assertEquals($expected, Connection::escapeSqlWildcards($sql));
+        self::assertEquals($expected, Connection::escapeSqlWildcards($sql));
     }
 
     public function dataForTestDefactoToRegExpWildcards(): iterable
@@ -95,6 +95,6 @@ class ConnectionTest extends TestCase
      */
     public function testDefactoToRegExpWildcards(string $defacto, string $expected): void
     {
-        $this->assertEquals($expected, Connection::defactoToRegExpWildcards($defacto));
+        self::assertEquals($expected, Connection::defactoToRegExpWildcards($defacto));
     }
 }

--- a/test/Database/ManyToManyTest.php
+++ b/test/Database/ManyToManyTest.php
@@ -43,63 +43,63 @@ class ManyToManyTest extends TestCase
     public function testConstructorDefaults(): void
     {
         $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id");
-        $this->assertEquals("id", $relation->localKey());
-        $this->assertEquals("id", $relation->relatedKey());
+        self::assertEquals("id", $relation->localKey());
+        self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testConstructorWithLocalKey(): void
     {
         $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_id");
-        $this->assertEquals("the_id", $relation->localKey());
-        $this->assertEquals("id", $relation->relatedKey());
+        self::assertEquals("the_id", $relation->localKey());
+        self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testConstructorWithRelatedKey(): void
     {
         $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", null, "the_related_id");
-        $this->assertEquals("id", $relation->localKey());
-        $this->assertEquals("the_related_id", $relation->relatedKey());
+        self::assertEquals("id", $relation->localKey());
+        self::assertEquals("the_related_id", $relation->relatedKey());
     }
 
     public function testConstructorWithLocalAndRelatedKey(): void
     {
         $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_local_id", "the_related_id");
-        $this->assertEquals("the_local_id", $relation->localKey());
-        $this->assertEquals("the_related_id", $relation->relatedKey());
+        self::assertEquals("the_local_id", $relation->localKey());
+        self::assertEquals("the_related_id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        $this->assertSame("pk_on_foo", $this->m_relation->localKey());
+        self::assertSame("pk_on_foo", $this->m_relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        $this->assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->m_local, $this->m_relation->localModel());
     }
 
     public function testPivotLocalKey(): void
     {
-        $this->assertEquals("foo_id", $this->m_relation->pivotLocalKey());
+        self::assertEquals("foo_id", $this->m_relation->pivotLocalKey());
     }
 
     public function testPivotRelatedKey(): void
     {
-        $this->assertEquals("bar_id", $this->m_relation->pivotRelatedKey());
+        self::assertEquals("bar_id", $this->m_relation->pivotRelatedKey());
     }
 
     public function testPivotModel(): void
     {
-        $this->assertEquals("FooBarLink", $this->m_relation->pivotModel());
+        self::assertEquals("FooBarLink", $this->m_relation->pivotModel());
     }
 
     public function testRelatedKey(): void
     {
-        $this->assertEquals("pk_on_bar", $this->m_relation->relatedKey());
+        self::assertEquals("pk_on_bar", $this->m_relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        $this->assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->m_relation->relatedModel());
     }
 }

--- a/test/Database/ManyToOneTest.php
+++ b/test/Database/ManyToOneTest.php
@@ -40,29 +40,29 @@ class ManyToOneTest extends TestCase
     public function testConstructor(): void
     {
         $relation = new ManyToOne($this->m_local, "Bar", "id", "bar_id");
-        $this->assertSame($this->m_local, $relation->localModel());
-        $this->assertEquals("Bar", $this->m_relation->relatedModel());
-        $this->assertEquals("bar_id", $relation->localKey());
-        $this->assertEquals("id", $relation->relatedKey());
+        self::assertSame($this->m_local, $relation->localModel());
+        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("bar_id", $relation->localKey());
+        self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        $this->assertSame("bar_id", $this->m_relation->localKey());
+        self::assertSame("bar_id", $this->m_relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        $this->assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->m_local, $this->m_relation->localModel());
     }
 
     public function testRelatedKey(): void
     {
-        $this->assertEquals("id", $this->m_relation->relatedKey());
+        self::assertEquals("id", $this->m_relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        $this->assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->m_relation->relatedModel());
     }
 }

--- a/test/Database/ModelTest.php
+++ b/test/Database/ModelTest.php
@@ -255,9 +255,9 @@ class ModelTest extends TestCase
         }
 
         $model = static::createModel($modelProperties, $modelData);
-        $this->assertEquals($expectedValue, $model->{$property}, "The model's {$property} property does not match the expected value.");
+        self::assertEquals($expectedValue, $model->{$property}, "The model's {$property} property does not match the expected value.");
         $model->{$property} = $newValue;
-        $this->assertEquals($expectedNewValue, $model->{$property}, "The model's {$property} property was not set to the expected value.");
+        self::assertEquals($expectedNewValue, $model->{$property}, "The model's {$property} property was not set to the expected value.");
     }
 
 	/**
@@ -323,9 +323,9 @@ class ModelTest extends TestCase
 
 		$model->foo_bar = $value;
 		$actual = $model->foo_bar;
-		$this->assertIsArray($actual, "Value of foo_bar property expected to be array.");
-		$this->assertEquals($expected, $actual, "Value of foo_bar does not match expected.");
-		$this->assertEquals(1, $callTracker->callCount(), "Custom accessor was not called the correct number of times.");
+		self::assertIsArray($actual, "Value of foo_bar property expected to be array.");
+		self::assertEquals($expected, $actual, "Value of foo_bar does not match expected.");
+		self::assertEquals(1, $callTracker->callCount(), "Custom accessor was not called the correct number of times.");
 	}
 
 	/**
@@ -402,8 +402,8 @@ class ModelTest extends TestCase
 
 		$model->foo_bar = $value;
 		$actual = $modelData->getValue($model)["foo_bar"];
-		$this->assertIsString($actual, "Value of foo_bar property expected to be string.");
-		$this->assertEquals($expected, $actual, "Value of foo_bar does not match expected.");
-		$this->assertEquals(1, $callTracker->callCount(), "Custom mutator was not called the correct number of times.");
+		self::assertIsString($actual, "Value of foo_bar property expected to be string.");
+		self::assertEquals($expected, $actual, "Value of foo_bar does not match expected.");
+		self::assertEquals(1, $callTracker->callCount(), "Custom mutator was not called the correct number of times.");
 	}
 }

--- a/test/Database/OneToManyTest.php
+++ b/test/Database/OneToManyTest.php
@@ -40,29 +40,29 @@ class OneToManyTest extends TestCase
     public function testConstructor(): void
     {
         $relation = new OneToMany($this->m_local, "Bar", "foo_id", "id");
-        $this->assertSame($this->m_local, $relation->localModel());
-        $this->assertEquals("Bar", $this->m_relation->relatedModel());
-        $this->assertEquals("id", $relation->localKey());
-        $this->assertEquals("foo_id", $relation->relatedKey());
+        self::assertSame($this->m_local, $relation->localModel());
+        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("id", $relation->localKey());
+        self::assertEquals("foo_id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        $this->assertSame("id", $this->m_relation->localKey());
+        self::assertSame("id", $this->m_relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        $this->assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->m_local, $this->m_relation->localModel());
     }
 
     public function testRelatedKey(): void
     {
-        $this->assertEquals("foo_id", $this->m_relation->relatedKey());
+        self::assertEquals("foo_id", $this->m_relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        $this->assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->m_relation->relatedModel());
     }
 }

--- a/test/Database/QueryBuilderTest.php
+++ b/test/Database/QueryBuilderTest.php
@@ -112,7 +112,7 @@ class QueryBuilderTest extends TestCase
     {
         $builder = new QueryBuilder();
         $this->m_application->shouldHaveReceived("database")->once();
-        $this->assertSame($this->m_defaultConnection, $builder->connection());
+        self::assertSame($this->m_defaultConnection, $builder->connection());
     }
 
     public function testConstructorWithConnection(): void
@@ -120,7 +120,7 @@ class QueryBuilderTest extends TestCase
         $connection = Mockery::mock(Connection::class);
         $builder = new QueryBuilder($connection);
         $this->m_application->shouldNotHaveReceived("database");
-        $this->assertSame($connection, $builder->connection());
+        self::assertSame($connection, $builder->connection());
     }
 
     public function dataForTestSetConnection(): iterable
@@ -151,7 +151,7 @@ class QueryBuilderTest extends TestCase
 
         $builder = new QueryBuilder();
         $builder->setConnection($connection);
-        $this->assertSame($connection, $builder->connection());
+        self::assertSame($connection, $builder->connection());
     }
 
     /**
@@ -161,9 +161,9 @@ class QueryBuilderTest extends TestCase
     {
         $builder = new QueryBuilder();
         $connection = Mockery::mock(PDO::class);
-        $this->assertSame($this->m_defaultConnection, $builder->connection());
+        self::assertSame($this->m_defaultConnection, $builder->connection());
         $builder->setConnection($connection);
-        $this->assertSame($connection, $builder->connection());
+        self::assertSame($connection, $builder->connection());
     }
 
     /**
@@ -196,8 +196,8 @@ class QueryBuilderTest extends TestCase
     {
         $builder = self::createBuilder($initialSelects, $tables);
         $actual = $builder->select($select);
-        $this->assertSame($builder, $actual, "QueryBuilder::select() did not return the same QueryBuilder instance.");
-        $this->assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::select() did not return the same QueryBuilder instance.");
+        self::assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -244,8 +244,8 @@ class QueryBuilderTest extends TestCase
         }
 
         $actual = $builder->addSelect($addSelects);
-        $this->assertSame($builder, $actual, "QueryBuilder::addSelect() did not return the same QueryBuilder instance.");
-        $this->assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::addSelect() did not return the same QueryBuilder instance.");
+        self::assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -303,8 +303,8 @@ class QueryBuilderTest extends TestCase
         
         $builder = self::createBuilder($initialSelects, $tables);
         $actual = $builder->addRawSelect($expression, $alias);
-        $this->assertSame($builder, $actual, "QueryBuilder::addSelect() did not return the same QueryBuilder instance.");
-        $this->assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::addSelect() did not return the same QueryBuilder instance.");
+        self::assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -356,8 +356,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"]);
         $actual = $builder->from($tables, $alias);
-        $this->assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM {$sqlFrom}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM {$sqlFrom}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -397,10 +397,10 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"]);
         $actual = $builder->from($table, $alias);
-        $this->assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
+        self::assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
         $actual = $builder->from($otherTable, $otherAlias);
-        $this->assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
-        $this->assertEquals(
+        self::assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
+        self::assertEquals(
             "SELECT `foo`,`bar` FROM `{$table}`" . (isset($alias) ? " AS `{$alias}`" : "") . ",`{$otherTable}`" . (isset($otherAlias) ? " AS `{$otherAlias}`" : ""),
             $builder->sql(),
             "The QueryBuilder did not generate the expected SQL."
@@ -465,8 +465,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"]);
         $actual = $builder->rawFrom($expression, $alias);
-        $this->assertSame($builder, $actual, "QueryBuilder::rawFrom() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM {$sqlFrom}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::rawFrom() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM {$sqlFrom}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -506,10 +506,10 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"]);
         $actual = $builder->rawFrom($expression, $alias);
-        $this->assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
+        self::assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
         $actual = $builder->rawFrom($otherExpression, $otherAlias);
-        $this->assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
-        $this->assertEquals(
+        self::assertSame($builder, $actual, "QueryBuilder::from() did not return the same QueryBuilder instance.");
+        self::assertEquals(
             "SELECT `foo`,`bar` FROM {$expression}" . (isset($alias) ? " AS `{$alias}`" : "") . ",`{$otherExpression}`" . (isset($otherAlias) ? " AS `{$otherAlias}`" : ""),
             $builder->sql(),
             "The QueryBuilder did not generate the expected SQL."
@@ -572,8 +572,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->leftJoin($joinTable, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -642,8 +642,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->innerJoin($joinTable, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -712,8 +712,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->rightJoin($joinTable, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoin() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -793,8 +793,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->leftJoinAs($joinTable, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -874,8 +874,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->innerJoinAs($joinTable, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -955,8 +955,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->rightJoinAs($joinTable, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1036,8 +1036,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->rawLeftJoin($joinExpression, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1127,8 +1127,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->rawRightJoin($joinExpression, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1218,8 +1218,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder(["foo", "bar"], $queryTable);
         $actual = $builder->rawInnerJoin($joinExpression, $alias, "foobar", $foreignFieldOrPairs, $localFieldOrOperator, $localField);
-        $this->assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::leftJoinAs() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlJoin}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1336,8 +1336,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = $this->createBuilder(["foo", "bar"], "foobar");
         $actual = $builder->where($field, $operatorOrValue, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::where() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlWhere}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::where() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar` FROM `foobar` {$sqlWhere}", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1414,14 +1414,14 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->where($closure);
-        $this->assertSame($builder, $actual, "QueryBuilder::orWhere() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::orWhere() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
 
         // test with orWhere() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar")->where("foo", "foo");
         $actual = $builder->orWhere($closure);
-        $this->assertSame($builder, $actual, "QueryBuilder::orWhere() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR {$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::orWhere() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR {$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1475,8 +1475,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNull($columns);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNull() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNull() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1530,8 +1530,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNotNull($columns);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNotNull() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNotNull() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1597,8 +1597,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereContains($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1664,8 +1664,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNotContains($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNotContains() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNotContains() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1731,8 +1731,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereStartsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1798,8 +1798,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNotStartsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNotStartsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNotStartsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1865,8 +1865,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereEndsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereEndsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereEndsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -1932,8 +1932,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNotEndsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNotEndsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNotEndsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2012,8 +2012,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereIn($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2090,8 +2090,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereNotIn($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2185,8 +2185,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->whereLength($columnOrPairs, $length);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2196,11 +2196,11 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->where("foo", "foo");
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->orWhere("foo", "bar");
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->sql();
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR `foo` = 'bar')", $actual);
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR `foo` = 'bar')", $actual);
     }
 
     /**
@@ -2210,11 +2210,11 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->where("foo", 3);
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->orWhere("foo", ">", 42);
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->sql();
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 3 OR `foo` > 42)", $actual);
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 3 OR `foo` > 42)", $actual);
     }
 
     /**
@@ -2224,7 +2224,7 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->where("foo", 3);
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $this->expectException(InvalidOperatorException::class);
         $actual = $builder->orWhere("foo", "", 42);
     }
@@ -2236,11 +2236,11 @@ class QueryBuilderTest extends TestCase
     {
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->where("foo", "foo");
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->orWhere(["foo" => "bar", "bar" => "fizz", "fizz" => "buzz",]);
-        $this->assertSame($builder, $actual);
+        self::assertSame($builder, $actual);
         $actual = $builder->sql();
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR `foo` = 'bar' OR `bar` = 'fizz' OR `fizz` = 'buzz')", $actual);
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE (`foo` = 'foo' OR `foo` = 'bar' OR `bar` = 'fizz' OR `fizz` = 'buzz')", $actual);
     }
 
     /**
@@ -2293,8 +2293,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNull($columns);
-        $this->assertSame($builder, $actual, "QueryBuilder::orWhereNull() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::orWhereNull() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2347,8 +2347,8 @@ class QueryBuilderTest extends TestCase
 
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNotNull($columns);
-        $this->assertSame($builder, $actual, "QueryBuilder::orWhereNull() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::orWhereNull() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2414,8 +2414,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereContains($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
 
@@ -2482,8 +2482,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNotContains($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereContains() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2549,8 +2549,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereStartsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2616,8 +2616,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNotStartsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereStartsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2683,8 +2683,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereEndsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereEndsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereEndsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2750,8 +2750,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNotEndsWith($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereNotEndsWith() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereNotEndsWith() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -2830,8 +2830,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereIn($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
 
@@ -2912,8 +2912,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereNotIn($columnOrPairs, $value);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     /**
@@ -3007,8 +3007,8 @@ class QueryBuilderTest extends TestCase
         // test with where() method
         $builder = $this->createBuilder(["foo", "bar", "fizz", "buzz",], "foobar");
         $actual = $builder->orWhereLength($columnOrPairs, $length);
-        $this->assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
-        $this->assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::whereIn() did not return the same QueryBuilder instance.");
+        self::assertEquals("SELECT `foo`,`bar`,`fizz`,`buzz` FROM `foobar` WHERE ({$sqlWhere})", $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 
     public function dataForTestOrderBy(): iterable
@@ -3086,7 +3086,7 @@ class QueryBuilderTest extends TestCase
             $expectedSql = "SELECT `foo`,`bar`,`buzz` FROM `foobar` ORDER BY {$sqlOrderBy}";
         }
 
-        $this->assertEquals($expectedSql, $builder->sql());
+        self::assertEquals($expectedSql, $builder->sql());
     }
 
     public function dataForTestRawOrderBy(): iterable
@@ -3159,7 +3159,7 @@ class QueryBuilderTest extends TestCase
             $expectedSql = "SELECT `foo`,`bar`,`buzz` FROM `foobar` ORDER BY {$sqlOrderBy}";
         }
 
-        $this->assertEquals($expectedSql, $builder->sql());
+        self::assertEquals($expectedSql, $builder->sql());
     }
 
     /**
@@ -3174,7 +3174,7 @@ class QueryBuilderTest extends TestCase
         } catch (InvalidOrderByDirectionException $err) {
         }
 
-        $this->assertEquals("SELECT `foo`,`bar`,`baz` FROM `foobar` WHERE (`foo` = 'foo') ORDER BY `foo` DESC", $builder->sql());
+        self::assertEquals("SELECT `foo`,`bar`,`baz` FROM `foobar` WHERE (`foo` = 'foo') ORDER BY `foo` DESC", $builder->sql());
     }
 
     /**
@@ -3212,7 +3212,7 @@ class QueryBuilderTest extends TestCase
 
         $builder = self::createBuilder($columns, $tables);
         $actual = $builder->limit($limit, $offset);
-        $this->assertSame($builder, $actual, "QueryBuilder::limit() did not return the same QueryBuilder instance.");
-        $this->assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
+        self::assertSame($builder, $actual, "QueryBuilder::limit() did not return the same QueryBuilder instance.");
+        self::assertEquals($sql, $builder->sql(), "The QueryBuilder did not generate the expected SQL.");
     }
 }

--- a/test/Exceptions/AssertsCommonExceptionProperties.php
+++ b/test/Exceptions/AssertsCommonExceptionProperties.php
@@ -6,23 +6,29 @@ use Throwable;
 
 trait AssertsCommonExceptionProperties
 {
-    private function assertMessage(Throwable $throwable, string $message): void
+    abstract public static function assertEquals(mixed $expected, mixed $actual, string $message = ""): void;
+
+    abstract public static function assertSame(mixed $expected, mixed $actual, string $message = ""): void;
+
+    abstract public static function assertMatchesRegularExpression(string $expected, string $actual, string $message = ""): void;
+
+    private static function assertMessage(Throwable $throwable, string $message): void
     {
-        $this->assertEquals($message, $throwable->getMessage());
+        self::assertEquals($message, $throwable->getMessage());
     }
 
-    private function assertMessageMatches(Throwable $throwable, string $pattern): void
+    private static function assertMessageMatches(Throwable $throwable, string $pattern): void
     {
-        $this->assertMatchesRegularExpression($message, $throwable->getMessage());
+        self::assertMatchesRegularExpression($message, $throwable->getMessage());
     }
 
-    private function assertCode(Throwable $throwable, int $code): void
+    private static function assertCode(Throwable $throwable, int $code): void
     {
-        $this->assertEquals($code, $throwable->getCode());
+        self::assertEquals($code, $throwable->getCode());
     }
 
-    private function assertPrevious(Throwable $throwable, ?Throwable $previous): void
+    private static function assertPrevious(Throwable $throwable, ?Throwable $previous): void
     {
-        $this->assertSame($previous, $throwable->getPrevious());
+        self::assertSame($previous, $throwable->getPrevious());
     }
 }

--- a/test/Exceptions/Database/DuplicateColumnNameExceptionTest.php
+++ b/test/Exceptions/Database/DuplicateColumnNameExceptionTest.php
@@ -14,37 +14,37 @@ class DuplicateColumnNameExceptionTest extends TestCase
     public function testWithColumnName(): void
     {
         $err = new DuplicateColumnNameException("column");
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameAndMessage(): void
     {
         $err = new DuplicateColumnNameException("column", "Message.");
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameMessageAndCode(): void
     {
         $err = new DuplicateColumnNameException("column", "Message.", 42);
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new DuplicateColumnNameException("column", "Message.", 42, $previous);
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/DuplicateTableNameExceptionTest.php
+++ b/test/Exceptions/Database/DuplicateTableNameExceptionTest.php
@@ -14,37 +14,37 @@ class DuplicateTableNameExceptionTest extends TestCase
     public function testWithTableName(): void
     {
         $err = new DuplicateTableNameException("table");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameAndMessage(): void
     {
         $err = new DuplicateTableNameException("table", "Message.");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageAndCode(): void
     {
         $err = new DuplicateTableNameException("table", "Message.", 42);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new DuplicateTableNameException("table", "Message.", 42, $previous);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidColumnNameExceptionTest.php
+++ b/test/Exceptions/Database/InvalidColumnNameExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidColumnNameExceptionTest extends TestCase
     public function testWithColumnName(): void
     {
         $err = new InvalidColumnNameException("column");
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameAndMessage(): void
     {
         $err = new InvalidColumnNameException("column", "Message.");
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameMessageAndCode(): void
     {
         $err = new InvalidColumnNameException("column", "Message.", 42);
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithColumnNameMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidColumnNameException("column", "Message.", 42, $previous);
-        $this->assertEquals("column", $err->getColumnName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("column", $err->getColumnName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidLimitExceptionTest.php
+++ b/test/Exceptions/Database/InvalidLimitExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidLimitExceptionTest extends TestCase
     public function testWithLimit(): void
     {
         $err = new InvalidLimitException(42);
-        $this->assertEquals(42, $err->getLimit());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getLimit());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitAndMessage(): void
     {
         $err = new InvalidLimitException(42, "Message.");
-        $this->assertEquals(42, $err->getLimit());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getLimit());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitMessageAndCode(): void
     {
         $err = new InvalidLimitException(42, "Message.", 42);
-        $this->assertEquals(42, $err->getLimit());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getLimit());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidLimitException(42, "Message.", 42, $previous);
-        $this->assertEquals(42, $err->getLimit());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(42, $err->getLimit());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidLimitOffsetExceptionTest.php
+++ b/test/Exceptions/Database/InvalidLimitOffsetExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidLimitOffsetExceptionTest extends TestCase
     public function testWithLimitOffset(): void
     {
         $err = new InvalidLimitOffsetException(42);
-        $this->assertEquals(42, $err->getOffset());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getOffset());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitOffsetAndMessage(): void
     {
         $err = new InvalidLimitOffsetException(42, "Message.");
-        $this->assertEquals(42, $err->getOffset());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getOffset());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitOffsetMessageAndCode(): void
     {
         $err = new InvalidLimitOffsetException(42, "Message.", 42);
-        $this->assertEquals(42, $err->getOffset());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(42, $err->getOffset());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithLimitOffsetMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidLimitOffsetException(42, "Message.", 42, $previous);
-        $this->assertEquals(42, $err->getOffset());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(42, $err->getOffset());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidOperatorExceptionTest.php
+++ b/test/Exceptions/Database/InvalidOperatorExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidOperatorExceptionTest extends TestCase
     public function testWithOperator(): void
     {
         $err = new InvalidOperatorException("->");
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorAndMessage(): void
     {
         $err = new InvalidOperatorException("->", "Message.");
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageAndCode(): void
     {
         $err = new InvalidOperatorException("->", "Message.", 42);
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidOperatorException("->", "Message.", 42, $previous);
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidOrderByDirectionExceptionTest.php
+++ b/test/Exceptions/Database/InvalidOrderByDirectionExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidOrderByDirectionExceptionTest extends TestCase
     public function testWithOrderByDirection(): void
     {
         $err = new InvalidOrderByDirectionException("random");
-        $this->assertEquals("random", $err->getDirection());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("random", $err->getDirection());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOrderByDirectionAndMessage(): void
     {
         $err = new InvalidOrderByDirectionException("random", "Message.");
-        $this->assertEquals("random", $err->getDirection());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("random", $err->getDirection());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOrderByDirectionMessageAndCode(): void
     {
         $err = new InvalidOrderByDirectionException("random", "Message.", 42);
-        $this->assertEquals("random", $err->getDirection());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("random", $err->getDirection());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOrderByDirectionMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidOrderByDirectionException("random", "Message.", 42, $previous);
-        $this->assertEquals("random", $err->getDirection());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("random", $err->getDirection());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidQueryExpressionExceptionTest.php
+++ b/test/Exceptions/Database/InvalidQueryExpressionExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidQueryExpressionExceptionTest extends TestCase
     public function testWithQueryExpression(): void
     {
         $err = new InvalidQueryExpressionException("foo -> bar");
-        $this->assertEquals("foo -> bar", $err->getExpression());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("foo -> bar", $err->getExpression());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithQueryExpressionAndMessage(): void
     {
         $err = new InvalidQueryExpressionException("foo -> bar", "Message.");
-        $this->assertEquals("foo -> bar", $err->getExpression());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("foo -> bar", $err->getExpression());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithQueryExpressionMessageAndCode(): void
     {
         $err = new InvalidQueryExpressionException("foo -> bar", "Message.", 42);
-        $this->assertEquals("foo -> bar", $err->getExpression());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("foo -> bar", $err->getExpression());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithQueryExpressionMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidQueryExpressionException("foo -> bar", "Message.", 42, $previous);
-        $this->assertEquals("foo -> bar", $err->getExpression());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("foo -> bar", $err->getExpression());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/InvalidTableNameExceptionTest.php
+++ b/test/Exceptions/Database/InvalidTableNameExceptionTest.php
@@ -14,37 +14,37 @@ class InvalidTableNameExceptionTest extends TestCase
     public function testWithTableName(): void
     {
         $err = new InvalidTableNameException("table");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameAndMessage(): void
     {
         $err = new InvalidTableNameException("table", "Message.");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageAndCode(): void
     {
         $err = new InvalidTableNameException("table", "Message.", 42);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new InvalidTableNameException("table", "Message.", 42, $previous);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/ModelPropertyCastExceptionTest.php
+++ b/test/Exceptions/Database/ModelPropertyCastExceptionTest.php
@@ -15,41 +15,41 @@ class UnknownRelationExceptionTest extends TestCase
     public function testWithModelAndRelation(): void
     {
         $err = new UnknownRelationException(Model::class, "foo");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getRelation());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getRelation());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelRelationAndMessage(): void
     {
         $err = new UnknownRelationException(Model::class, "foo", "Message.");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getRelation());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getRelation());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageAndCode(): void
     {
         $err = new UnknownRelationException(Model::class, "foo", "Message.", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getRelation());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getRelation());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new UnknownRelationException(Model::class, "foo", "Message.", 42, $previous);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getRelation());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getRelation());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/OrphanedJoinExceptionTest.php
+++ b/test/Exceptions/Database/OrphanedJoinExceptionTest.php
@@ -14,37 +14,37 @@ class OrphanedJoinExceptionTest extends TestCase
     public function testWithTableName(): void
     {
         $err = new OrphanedJoinException("table");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameAndMessage(): void
     {
         $err = new OrphanedJoinException("table", "Message.");
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageAndCode(): void
     {
         $err = new OrphanedJoinException("table", "Message.", 42);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithTableNameMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new OrphanedJoinException("table", "Message.", 42, $previous);
-        $this->assertEquals("table", $err->getTableName());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("table", $err->getTableName());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/UnknownRelationExceptionTest.php
+++ b/test/Exceptions/Database/UnknownRelationExceptionTest.php
@@ -15,180 +15,180 @@ class ModelPropertyCastExceptionTest extends TestCase
     public function testWithModelPropertyAndIntValue(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(42, $err->getValue());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(42, $err->getValue());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyIntValueAndMessage(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 42, "Message.");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(42, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(42, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyIntValueMessageAndCode(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 42, "Message.", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(42, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(42, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyIntValueMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new ModelPropertyCastException(Model::class, "foo", 42, "Message.", 42, $previous);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(42, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(42, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 
     public function testWithModelPropertyAndFloatValue(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 3.1415927);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(3.1415927, $err->getValue());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(3.1415927, $err->getValue());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyFloatValueAndMessage(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 3.1415927, "Message.");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(3.1415927, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(3.1415927, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyFloatValueMessageAndCode(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", 3.1415927, "Message.", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(3.1415927, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(3.1415927, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyFloatValueMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new ModelPropertyCastException(Model::class, "foo", 3.1415927, "Message.", 42, $previous);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(3.1415927, $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(3.1415927, $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 
     public function testWithModelPropertyAndStringValue(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", "value");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals("value", $err->getValue());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals("value", $err->getValue());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyStringValueAndMessage(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", "value", "Message.");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals("value", $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals("value", $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyStringValueMessageAndCode(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", "value", "Message.", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals("value", $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals("value", $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyStringValueMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new ModelPropertyCastException(Model::class, "foo", "value", "Message.", 42, $previous);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals("value", $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals("value", $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 
     public function testWithModelPropertyAndArrayValue(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", ["foo", "bar",]);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(["foo", "bar",], $err->getValue());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(["foo", "bar",], $err->getValue());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyArrayValueAndMessage(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", ["foo", "bar",], "Message.");
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(["foo", "bar",], $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(["foo", "bar",], $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyArrayValueMessageAndCode(): void
     {
         $err = new ModelPropertyCastException(Model::class, "foo", ["foo", "bar",], "Message.", 42);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(["foo", "bar",], $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(["foo", "bar",], $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithModelModelPropertyArrayValueMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new ModelPropertyCastException(Model::class, "foo", ["foo", "bar",], "Message.", 42, $previous);
-        $this->assertEquals(Model::class, $err->getModel());
-        $this->assertEquals("foo", $err->getProperty());
-        $this->assertEquals(["foo", "bar",], $err->getValue());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals(Model::class, $err->getModel());
+        self::assertEquals("foo", $err->getProperty());
+        self::assertEquals(["foo", "bar",], $err->getValue());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Exceptions/Database/UnrecognisedQueryOperatorExceptionTest.php
+++ b/test/Exceptions/Database/UnrecognisedQueryOperatorExceptionTest.php
@@ -14,37 +14,37 @@ class UnrecognisedQueryOperatorExceptionTest extends TestCase
     public function testWithOperator(): void
     {
         $err = new UnrecognisedQueryOperatorException("->");
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorAndMessage(): void
     {
         $err = new UnrecognisedQueryOperatorException("->", "Message.");
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 0);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 0);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageAndCode(): void
     {
         $err = new UnrecognisedQueryOperatorException("->", "Message.", 42);
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, null);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, null);
     }
 
     public function testWithOperatorMessageCodeAndPrevious(): void
     {
         $previous = new Exception();
         $err = new UnrecognisedQueryOperatorException("->", "Message.", 42, $previous);
-        $this->assertEquals("->", $err->getOperator());
-        $this->assertMessage($err, "Message.");
-        $this->assertCode($err, 42);
-        $this->assertPrevious($err, $previous);
+        self::assertEquals("->", $err->getOperator());
+        self::assertMessage($err, "Message.");
+        self::assertCode($err, 42);
+        self::assertPrevious($err, $previous);
     }
 }

--- a/test/Framework/RuleTestCase.php
+++ b/test/Framework/RuleTestCase.php
@@ -67,6 +67,6 @@ abstract class RuleTestCase extends TestCase
         }
 
         $rule = new Integer();
-        $this->assertIsString($rule->message($field), "The message method did not produce a string.");
+        self::assertIsString($rule->message($field), "The message method did not produce a string.");
     }
 }

--- a/test/Helpers/I18nTest.php
+++ b/test/Helpers/I18nTest.php
@@ -81,7 +81,7 @@ final class I18nTest extends TestCase
 			->andReturn($this->m_translator);
 
 		$actual = tr($str, __FILE__, __LINE__, ...$args);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	public function testTrWithoutTranslator(): void
@@ -89,17 +89,17 @@ final class I18nTest extends TestCase
 		$this->m_app->shouldReceive("translator")
 			->andReturn(null);
 
-		$this->assertEquals("foo", tr("foo"));
-		$this->assertEquals("foo bar", tr("foo %1", __FILE__, __LINE__, "bar"));
-		$this->assertEquals("foo bar baz", tr("foo %2 %1", __FILE__, __LINE__, "baz", "bar"));
+		self::assertEquals("foo", tr("foo"));
+		self::assertEquals("foo bar", tr("foo %1", __FILE__, __LINE__, "bar"));
+		self::assertEquals("foo bar baz", tr("foo %2 %1", __FILE__, __LINE__, "baz", "bar"));
 	}
 
 	public function testTrWithoutApp(): void
 	{
 		uopz_set_return(Application::class, "instance", null);
 
-		$this->assertEquals("foo", tr("foo"));
-		$this->assertEquals("foo bar", tr("foo %1", __FILE__, __LINE__, "bar"));
-		$this->assertEquals("foo bar baz", tr("foo %2 %1", __FILE__, __LINE__, "baz", "bar"));
+		self::assertEquals("foo", tr("foo"));
+		self::assertEquals("foo bar", tr("foo %1", __FILE__, __LINE__, "bar"));
+		self::assertEquals("foo bar baz", tr("foo %2 %1", __FILE__, __LINE__, "baz", "bar"));
 	}
 }

--- a/test/Helpers/IterableTest.php
+++ b/test/Helpers/IterableTest.php
@@ -122,27 +122,27 @@ final class IterableTest extends TestCase
 				$this->index = 0;
 			}
 
-			public function current()
+			public function current(): mixed
 			{
 				return $this->data[$this->index] ?? null;
 			}
 
-			public function next()
+			public function next(): void
 			{
 				++$this->index;
 			}
 
-			public function rewind()
+			public function rewind(): void
 			{
 				$this->index = 0;
 			}
 
-			public function valid()
+			public function valid(): bool
 			{
 				return count($this->data) > $this->index;
 			}
 
-			public function key()
+			public function key(): mixed
 			{
 				return $this->valid() ? $this->index : null;
 			}
@@ -230,8 +230,8 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = map($data, $fn);
-		$this->assertIsIterable($actual);
-		$this->assertEquals(toArray($expected), toArray($actual));
+		self::assertIsIterable($actual);
+		self::assertEquals(toArray($expected), toArray($actual));
 	}
 
 	/**
@@ -295,8 +295,8 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = flatten($data);
-		$this->assertIsIterable($actual);
-		$this->assertEquals(toArray($expected), toArray($actual));
+		self::assertIsIterable($actual);
+		self::assertEquals(toArray($expected), toArray($actual));
 	}
 
 	/**
@@ -363,8 +363,8 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = toArray($data);
-		$this->assertIsArray($actual);
-		$this->assertEquals($expected, $actual);
+		self::assertIsArray($actual);
+		self::assertEquals($expected, $actual);
 	}
 
 
@@ -539,8 +539,8 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = implode($glue, $iterable);
-		$this->assertIsString($actual);
-		$this->assertEquals($expected, $actual);
+		self::assertIsString($actual);
+		self::assertEquals($expected, $actual);
 	}
 
 
@@ -781,8 +781,8 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = grammaticalImplode($iterable, $glue, $lastGlue);
-		$this->assertIsString($actual);
-		$this->assertEquals($expected, $actual);
+		self::assertIsString($actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -791,8 +791,8 @@ final class IterableTest extends TestCase
 	public function testGrammaticalImplodeWithDefaultGlue(): void
 	{
 		$actual = grammaticalImplode(["red", "green", "blue"]);
-		$this->assertIsString($actual);
-		$this->assertEquals("red, green and blue", $actual);
+		self::assertIsString($actual);
+		self::assertEquals("red, green and blue", $actual);
 	}
 
 	/**
@@ -801,8 +801,8 @@ final class IterableTest extends TestCase
 	public function testGrammaticalImplodeWithDefaultLastGlue(): void
 	{
 		$actual = grammaticalImplode(["red", "green", "blue"], "; ");
-		$this->assertIsString($actual);
-		$this->assertEquals("red; green and blue", $actual);
+		self::assertIsString($actual);
+		self::assertEquals("red; green and blue", $actual);
 	}
 
 	/**
@@ -856,13 +856,13 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = transform($data, $fn);
-		$this->assertSame($data, $actual);
+		self::assertSame($data, $actual);
 
 		$expected = toArray($expected);
 		$actual = toArray($actual);
 
 		for ($idx = 0; $idx < count($expected); ++$idx) {
-			$this->assertEquals($expected[$idx], $actual[$idx]);
+			self::assertEquals($expected[$idx], $actual[$idx]);
 		}
 	}
 
@@ -880,7 +880,7 @@ final class IterableTest extends TestCase
 		})();
 
 		$actual = transform($data, fn($value) => $value);
-		$this->assertSame($data, $actual);
+		self::assertSame($data, $actual);
 	}
 
 	/**
@@ -978,7 +978,7 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = reduce($data, $fn, $init);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -1090,7 +1090,7 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = accumulate(...$args);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -1237,7 +1237,7 @@ final class IterableTest extends TestCase
 		}
 		
 		$actual = all($collection, $predicate);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 	
 	/**
@@ -1384,7 +1384,7 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = none($collection, $predicate);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 
@@ -1532,7 +1532,7 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = some($collection, $predicate);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -1654,7 +1654,7 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = isSubsetOf($subset, $set);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -1714,6 +1714,6 @@ final class IterableTest extends TestCase
 		}
 
 		$actual = recursiveCount($iterable);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 }

--- a/test/Helpers/StrTest.php
+++ b/test/Helpers/StrTest.php
@@ -85,7 +85,7 @@ final class StrTest extends TestCase
 		}
 
 		$actual = camelToSnake($str, $encoding);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 	
 	public function dataForTestSnakeToCamel(): iterable
@@ -142,7 +142,7 @@ final class StrTest extends TestCase
 		}
 
 		$actual = snakeToCamel($str, $encoding);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -196,7 +196,7 @@ final class StrTest extends TestCase
 		}
 
 		$actual = html($raw);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -262,7 +262,7 @@ final class StrTest extends TestCase
 		}
 
 		$actual = build($template, ...$args);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	public function dataForTestToCodePoints(): iterable
@@ -292,7 +292,7 @@ final class StrTest extends TestCase
 		}
 
 		$actual = toCodePoints($str, $encoding);
-		$this->assertEquals($expected, $actual);
+		self::assertEquals($expected, $actual);
 	}
 
 	/**
@@ -316,7 +316,7 @@ final class StrTest extends TestCase
 	public function testRandomLength(int $length): void
 	{
 		$actual = random($length);
-		$this->assertEquals($length, strlen($actual));
+		self::assertEquals($length, strlen($actual));
 	}
 
 
@@ -329,7 +329,7 @@ final class StrTest extends TestCase
 	public function testRandomContent(int $length): void
 	{
 		$actual = random($length);
-		$this->assertEquals($length, strspn($actual, "abcdefghijklmnopqrstuvwxyz-_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"));
+		self::assertEquals($length, strspn($actual, "abcdefghijklmnopqrstuvwxyz-_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"));
 	}
 
 	public function testRandomThrowsWithInvalidLength(): void

--- a/test/HtmlCleanerTest.php
+++ b/test/HtmlCleanerTest.php
@@ -52,11 +52,11 @@ class HtmlCleanerTest extends TestCase
      */
     private function checkAllowOrDenyList($list, string $name): void
     {
-        $this->assertIsArray($list, "{$name} is not an array");
+        self::assertIsArray($list, "{$name} is not an array");
 
         foreach ($list as $item) {
-            $this->assertIsString($item, "{$name} contains an non-string");
-            $this->assertNotEmpty($item, "{$name} contains an empty tag");
+            self::assertIsString($item, "{$name} contains an non-string");
+            self::assertNotEmpty($item, "{$name} contains an empty tag");
         }
     }
 
@@ -96,9 +96,9 @@ class HtmlCleanerTest extends TestCase
     public function testDefaultConstructor()
     {
         $this->checkAllAllowOrDenyLists($this->m_cleaner, "default");
-        $this->assertAttributeIsInt([$this->m_cleaner, "m_tagMode"], "tag filter mode of default cleaner is not an int");
-        $this->assertAttributeIsInt([$this->m_cleaner, "m_idMode"], "id filter mode of default cleaner is not an int");
-        $this->assertAttributeIsInt([$this->m_cleaner, "m_classMode"], "class filter mode of default cleaner is not an int");
+        self::assertAttributeIsInt([$this->m_cleaner, "m_tagMode"], "tag filter mode of default cleaner is not an int");
+        self::assertAttributeIsInt([$this->m_cleaner, "m_idMode"], "id filter mode of default cleaner is not an int");
+        self::assertAttributeIsInt([$this->m_cleaner, "m_classMode"], "class filter mode of default cleaner is not an int");
     }
 
     public function dataForTestConstructor(): array
@@ -163,31 +163,31 @@ class HtmlCleanerTest extends TestCase
 
         $cleaner = new HtmlCleaner(...$constructorArgs);
         $this->checkAllAllowOrDenyLists($cleaner);
-        $this->assertAttributeIsInt([$cleaner, "m_tagMode"], "tag filter mode of constructed cleaner is not an int");
-        $this->assertAttributeIsInt([$cleaner, "m_idMode"], "id filter mode of constructed cleaner is not an int");
-        $this->assertAttributeIsInt([$cleaner, "m_classMode"], "class filter mode of constructed cleaner is not an int");
+        self::assertAttributeIsInt([$cleaner, "m_tagMode"], "tag filter mode of constructed cleaner is not an int");
+        self::assertAttributeIsInt([$cleaner, "m_idMode"], "id filter mode of constructed cleaner is not an int");
+        self::assertAttributeIsInt([$cleaner, "m_classMode"], "class filter mode of constructed cleaner is not an int");
 
         if (isset($tagMode)) {
             if (self::isValidFilterMode($tagMode)) {
-                $this->assertSame($tagMode, $cleaner->tagMode(), "the tag filter mode {$cleaner->tagMode()} in the constructed object does not match the provided, valid mode {$tagMode}");
+                self::assertSame($tagMode, $cleaner->tagMode(), "the tag filter mode {$cleaner->tagMode()} in the constructed object does not match the provided, valid mode {$tagMode}");
             } else {
-                $this->assertNotSame($tagMode, $cleaner->tagMode(), "the tag filter mode {$cleaner->tagMode()} in the constructed object matches the provided, invalid mode {$tagMode}");
+                self::assertNotSame($tagMode, $cleaner->tagMode(), "the tag filter mode {$cleaner->tagMode()} in the constructed object matches the provided, invalid mode {$tagMode}");
             }
         }
 
         if (isset($idMode)) {
             if (self::isValidFilterMode($idMode)) {
-                $this->assertSame($idMode, $cleaner->idMode(), "the id filter mode {$cleaner->idMode()} in the constructed object does not match the provided, valid mode {$idMode}");
+                self::assertSame($idMode, $cleaner->idMode(), "the id filter mode {$cleaner->idMode()} in the constructed object does not match the provided, valid mode {$idMode}");
             } else {
-                $this->assertNotSame($idMode, $cleaner->idMode(), "the id filter mode {$cleaner->idMode()} in the constructed object matches the provided, invalid mode {$idMode}");
+                self::assertNotSame($idMode, $cleaner->idMode(), "the id filter mode {$cleaner->idMode()} in the constructed object matches the provided, invalid mode {$idMode}");
             }
         }
 
         if (isset($classMode)) {
             if (self::isValidFilterMode($classMode)) {
-                $this->assertSame($classMode, $cleaner->classMode(), "the class filter mode {$cleaner->classMode()} in the constructed object does not match the provided, valid mode {$classMode}");
+                self::assertSame($classMode, $cleaner->classMode(), "the class filter mode {$cleaner->classMode()} in the constructed object does not match the provided, valid mode {$classMode}");
             } else {
-                $this->assertNotSame($classMode, $cleaner->classMode(), "the class filter {$cleaner->classMode()} mode in the constructed object matches the provided, invalid mode {$classMode}");
+                self::assertNotSame($classMode, $cleaner->classMode(), "the class filter {$cleaner->classMode()} mode in the constructed object matches the provided, invalid mode {$classMode}");
             }
         }
     }
@@ -237,8 +237,8 @@ class HtmlCleanerTest extends TestCase
     public function testTagMode($mode, StdClass $expectation)
     {
         $oldMode = $this->m_cleaner->tagMode();
-        $this->assertIsInt($oldMode, "default tag name mode is not an integer");
-        $this->assertContains($oldMode, self::ValidModes);
+        self::assertIsInt($oldMode, "default tag name mode is not an integer");
+        self::assertContains($oldMode, self::ValidModes);
 
         if (!is_int($mode)) {
             $this->expectException("TypeError");
@@ -250,12 +250,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->setTagMode($mode);
         $actual = $this->m_cleaner->tagMode();
-        $this->assertIsInt($actual, "actual tag name mode is not an integer");
+        self::assertIsInt($actual, "actual tag name mode is not an integer");
 
         if (isset($expectation->value)) {
-            $this->assertSame($expectation->value, $actual, "actual tag name mode is not as expected after call to setTagMode({$mode})");
+            self::assertSame($expectation->value, $actual, "actual tag name mode is not as expected after call to setTagMode({$mode})");
         } else {
-            $this->assertSame($oldMode, $actual, "actual tag name mode is not unchanged after failed call to setTagMode({$mode})");
+            self::assertSame($oldMode, $actual, "actual tag name mode is not unchanged after failed call to setTagMode({$mode})");
         }
     }
 
@@ -273,8 +273,8 @@ class HtmlCleanerTest extends TestCase
     public function testIdMode($mode, StdClass $expectation)
     {
         $oldMode = $this->m_cleaner->idMode();
-        $this->assertIsInt($oldMode, "default ID mode is not an integer");
-        $this->assertContains($oldMode, self::ValidModes);
+        self::assertIsInt($oldMode, "default ID mode is not an integer");
+        self::assertContains($oldMode, self::ValidModes);
 
         if (!is_int($mode)) {
             $this->expectException("TypeError");
@@ -286,12 +286,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->setIdMode($mode);
         $actual = $this->m_cleaner->idMode();
-        $this->assertIsInt($actual, "actual ID mode is not an integer");
+        self::assertIsInt($actual, "actual ID mode is not an integer");
 
         if (isset($expectation->value)) {
-            $this->assertSame($expectation->value, $actual, "actual ID mode is not as expected after call to setIdMode({$mode})");
+            self::assertSame($expectation->value, $actual, "actual ID mode is not as expected after call to setIdMode({$mode})");
         } else {
-            $this->assertSame($oldMode, $actual, "actual ID mode is not unchanged after failed call to setIdMode({$mode})");
+            self::assertSame($oldMode, $actual, "actual ID mode is not unchanged after failed call to setIdMode({$mode})");
         }
     }
 
@@ -309,8 +309,8 @@ class HtmlCleanerTest extends TestCase
     public function testClassMode($mode, StdClass $expectation)
     {
         $oldMode = $this->m_cleaner->classMode();
-        $this->assertIsInt($oldMode, "default class mode is not an integer");
-        $this->assertContains($oldMode, self::ValidModes);
+        self::assertIsInt($oldMode, "default class mode is not an integer");
+        self::assertContains($oldMode, self::ValidModes);
 
         if (!is_int($mode)) {
             $this->expectException("TypeError");
@@ -322,12 +322,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->setClassMode($mode);
         $actual = $this->m_cleaner->classMode();
-        $this->assertIsInt($actual, "actual class mode is not an integer");
+        self::assertIsInt($actual, "actual class mode is not an integer");
 
         if (isset($expectation->value)) {
-            $this->assertSame($expectation->value, $actual, "actual class mode is not as expected after call to setClassMode({$mode})");
+            self::assertSame($expectation->value, $actual, "actual class mode is not as expected after call to setClassMode({$mode})");
         } else {
-            $this->assertSame($oldMode, $actual, "actual class mode is not unchanged after failed call to setClassMode({$mode})");
+            self::assertSame($oldMode, $actual, "actual class mode is not unchanged after failed call to setClassMode({$mode})");
         }
     }
 
@@ -409,12 +409,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->denyTags($denyList);
         $actualBlacklist = $this->m_cleaner->deniedTags();
-        $this->assertIsArray($actualBlacklist, "actual tags denylist is not an array");
+        self::assertIsArray($actualBlacklist, "actual tags denylist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual tags denylist is not as expected after call to denyTags()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual tags denylist is not as expected after call to denyTags()");
         } else {
-            $this->assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual tags denylist is not unchanged after failed call to denyTags()");
+            self::assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual tags denylist is not unchanged after failed call to denyTags()");
         }
     }
 
@@ -443,12 +443,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->allowTags($allowList);
         $actualAllowlist = $this->m_cleaner->allowedTags();
-        $this->assertIsArray($actualAllowlist, "actual tags allowlist is not an array");
+        self::assertIsArray($actualAllowlist, "actual tags allowlist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual tags allowlist is not as expected after call to allowTags()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual tags allowlist is not as expected after call to allowTags()");
         } else {
-            $this->assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual tags allowlist is not unchanged after failed call to allowTags()");
+            self::assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual tags allowlist is not unchanged after failed call to allowTags()");
         }
     }
 
@@ -530,12 +530,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->denyIds($denyList);
         $actualBlacklist = $this->m_cleaner->deniedIds();
-        $this->assertIsArray($actualBlacklist, "actual ids denylist is not an array");
+        self::assertIsArray($actualBlacklist, "actual ids denylist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual ids denylist is not as expected after call to denyIds()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual ids denylist is not as expected after call to denyIds()");
         } else {
-            $this->assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual ids denylist is not unchanged after failed call to denyIds()");
+            self::assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual ids denylist is not unchanged after failed call to denyIds()");
         }
     }
 
@@ -564,12 +564,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->allowIds($allowList);
         $actualAllowlist = $this->m_cleaner->allowedIds();
-        $this->assertIsArray($actualAllowlist, "actual ids allowlist is not an array");
+        self::assertIsArray($actualAllowlist, "actual ids allowlist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual ids allowlist is not as expected after call to allowIds()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual ids allowlist is not as expected after call to allowIds()");
         } else {
-            $this->assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual ids allowlist is not unchanged after failed call to allowIds()");
+            self::assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual ids allowlist is not unchanged after failed call to allowIds()");
         }
     }
 
@@ -651,12 +651,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->denyClasses($denyList);
         $actualBlacklist = $this->m_cleaner->deniedClasses();
-        $this->assertIsArray($actualBlacklist, "actual classes denylist is not an array");
+        self::assertIsArray($actualBlacklist, "actual classes denylist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual classes denylist is not as expected after call to denyClasses()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualBlacklist, "actual classes denylist is not as expected after call to denyClasses()");
         } else {
-            $this->assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual classes denylist is not unchanged after failed call to denyClasses()");
+            self::assertEqualsCanonicalizing($oldBlacklist, $actualBlacklist, "actual classes denylist is not unchanged after failed call to denyClasses()");
         }
     }
 
@@ -685,12 +685,12 @@ class HtmlCleanerTest extends TestCase
 
         $this->m_cleaner->allowClasses($allowList);
         $actualAllowlist = $this->m_cleaner->allowedClasses();
-        $this->assertIsArray($actualAllowlist, "actual classes allowlist is not an array");
+        self::assertIsArray($actualAllowlist, "actual classes allowlist is not an array");
 
         if (isset($expectation->value)) {
-            $this->assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual classes allowlist is not as expected after call to allowClasses()");
+            self::assertEqualsCanonicalizing($expectation->value, $actualAllowlist, "actual classes allowlist is not as expected after call to allowClasses()");
         } else {
-            $this->assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual classes allowlist is not unchanged after failed call to allowClasses()");
+            self::assertEqualsCanonicalizing($oldAllowlist, $actualAllowlist, "actual classes allowlist is not unchanged after failed call to allowClasses()");
         }
     }
 
@@ -751,7 +751,7 @@ class HtmlCleanerTest extends TestCase
             $this->m_cleaner->allowTags($allowedTags);
         }
         
-        $this->assertSame($allowed, $this->m_cleaner->isAllowedTag($tag));
+        self::assertSame($allowed, $this->m_cleaner->isAllowedTag($tag));
     }
 
 //    public function testIsAllowedNode()
@@ -1226,6 +1226,6 @@ class HtmlCleanerTest extends TestCase
         }
 
         $actualHtml = $this->m_cleaner->clean($testHtml);
-        $this->assertSame($expectedHtml, $actualHtml);
+        self::assertSame($expectedHtml, $actualHtml);
     }
 }

--- a/test/Responses/CanSetContentTypeTest.php
+++ b/test/Responses/CanSetContentTypeTest.php
@@ -23,7 +23,7 @@ final class CanSetContentTypeTest extends TestCase
     /** Ensure we can fetch the content-type. */
     public function testStatusCode(): void
     {
-        $this->assertEquals("application/octet-stream", $this->createInstance()->contentType());
+        self::assertEquals("application/octet-stream", $this->createInstance()->contentType());
     }
 
     /** Ensure we can set the content-type. */
@@ -31,6 +31,6 @@ final class CanSetContentTypeTest extends TestCase
     {
         $instance = $this->createInstance();
         $instance->setContentType("application/json");
-        $this->assertEquals("application/json", $instance->contentType());
+        self::assertEquals("application/json", $instance->contentType());
     }
 }

--- a/test/Responses/CanSetStatusCodeTest.php
+++ b/test/Responses/CanSetStatusCodeTest.php
@@ -28,7 +28,7 @@ final class CanSetStatusCodeTest extends TestCase
     /** Ensure we can fetch the status code. */
     public function testStatusCode(): void
     {
-        $this->assertEquals(200, $this->createInstance()->statusCode());
+        self::assertEquals(200, $this->createInstance()->statusCode());
     }
 
     /** Ensure we can set the status code. */
@@ -36,6 +36,6 @@ final class CanSetStatusCodeTest extends TestCase
     {
         $instance = $this->createInstance();
         $instance->setStatusCode(400);
-        $this->assertEquals(400, $instance->statusCode());
+        self::assertEquals(400, $instance->statusCode());
     }
 }

--- a/test/Responses/NaivelySendsContentTest.php
+++ b/test/Responses/NaivelySendsContentTest.php
@@ -104,6 +104,6 @@ final class NaivelySendsContentTest extends TestCase
 		self::assertEquals(1, $httpResponseCodeCalled);
 		self::assertEquals(self::TestContent, ob_get_contents());
 		ob_end_clean();
-		$this->assertEmpty($expectedHeaders, "Not all expected headers were generated.");
+		self::assertEmpty($expectedHeaders, "Not all expected headers were generated.");
 	}
 }

--- a/test/Responses/SendsHeadersTest.php
+++ b/test/Responses/SendsHeadersTest.php
@@ -65,6 +65,6 @@ final class SendsHeadersTest extends TestCase
 
         $instance = new XRay($this->createInstance());
         $instance->sendHeaders();
-        $this->assertEmpty($expectedHeaders, "Not all expected headers were generated.");
+        self::assertEmpty($expectedHeaders, "Not all expected headers were generated.");
     }
 }

--- a/test/RouterTest.php
+++ b/test/RouterTest.php
@@ -187,7 +187,7 @@ class RouterTest extends TestCase
 		$router = new XRay(new Router());
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerGet($route, $handler);
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route)));
 	}
 
 	/**
@@ -203,7 +203,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerPost($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PostMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PostMethod)));
 	}
 
 	/**
@@ -219,7 +219,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerPut($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PutMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PutMethod)));
 	}
 
 	/**
@@ -235,7 +235,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerDelete($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::DeleteMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::DeleteMethod)));
 	}
 
 	/**
@@ -251,7 +251,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerOptions($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::OptionsMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::OptionsMethod)));
 	}
 
 	/**
@@ -267,7 +267,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerHead($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::HeadMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::HeadMethod)));
 	}
 
 	/**
@@ -283,7 +283,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerConnect($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::ConnectMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::ConnectMethod)));
 	}
 
 	/**
@@ -299,7 +299,7 @@ class RouterTest extends TestCase
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exception. */
 		$router->registerPatch($route, $handler);
 		/** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-		$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PatchMethod)));
+		self::assertSame($route, $router->matchedRoute(self::makeRequest($route, RouterContract::PatchMethod)));
 	}
 
 	/**
@@ -1499,10 +1499,10 @@ class RouterTest extends TestCase
 		foreach ($methods as $method) {
 			if (RouterContract::AnyMethod === $method) {
 				foreach (self::allHttpMethods() as $anyMethod) {
-					$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, $anyMethod)));
+					self::assertSame($route, $router->matchedRoute(self::makeRequest($route, $anyMethod)));
 				}
 			} else {
-				$this->assertSame($route, $router->matchedRoute(self::makeRequest($route, $method)));
+				self::assertSame($route, $router->matchedRoute(self::makeRequest($route, $method)));
 			}
 		}
 	}
@@ -1516,8 +1516,8 @@ class RouterTest extends TestCase
 	{
 		return [
 			"typicalGetWithNoParameters" => [RouterContract::GetMethod, "/home", RouterContract::GetMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1526,8 +1526,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithLongerPathAndNoParameters" => [RouterContract::GetMethod, "/admin/users/home", RouterContract::GetMethod, "/admin/users/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/admin/users/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/admin/users/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1536,8 +1536,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::GetMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1546,8 +1546,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::PostMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1556,8 +1556,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::PutMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1566,8 +1566,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::DeleteMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1576,8 +1576,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::HeadMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1586,8 +1586,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::OptionsMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1596,8 +1596,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::ConnectMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1606,8 +1606,8 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithNoParameters" => [RouterContract::AnyMethod, "/home", RouterContract::PatchMethod, "/home", function(Request $request): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/home", $request->pathInfo());
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/home", $request->pathInfo());
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1616,9 +1616,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterInt" => [RouterContract::GetMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1627,9 +1627,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterString" => [RouterContract::GetMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1638,9 +1638,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterFloat" => [RouterContract::GetMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1649,9 +1649,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterBoolTrueInt" => [RouterContract::GetMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1660,9 +1660,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterBoolTrueString" => [RouterContract::GetMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1671,9 +1671,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterBoolFalseInt" => [RouterContract::GetMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1682,9 +1682,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParameterBoolFalseString" => [RouterContract::GetMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1693,9 +1693,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1704,9 +1704,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1715,9 +1715,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::GetMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1726,9 +1726,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1737,9 +1737,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1748,9 +1748,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1759,9 +1759,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyGetWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::GetMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1770,9 +1770,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PostMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1781,9 +1781,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PostMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1792,9 +1792,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PostMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1803,9 +1803,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PostMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1814,9 +1814,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PostMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1825,9 +1825,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PostMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1836,9 +1836,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPostWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PostMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1847,9 +1847,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PutMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1858,9 +1858,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PutMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1869,9 +1869,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PutMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1880,9 +1880,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PutMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1891,9 +1891,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PutMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1902,9 +1902,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PutMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1913,9 +1913,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPutWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PutMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1924,9 +1924,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::HeadMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1935,9 +1935,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::HeadMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1946,9 +1946,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::HeadMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1957,9 +1957,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::HeadMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1968,9 +1968,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::HeadMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1979,9 +1979,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::HeadMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -1990,9 +1990,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyHeadWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::HeadMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2001,9 +2001,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::ConnectMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2012,9 +2012,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::ConnectMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2023,9 +2023,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::ConnectMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2034,9 +2034,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::ConnectMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2045,9 +2045,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::ConnectMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2056,9 +2056,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::ConnectMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2067,9 +2067,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyConnectWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::ConnectMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2078,9 +2078,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::DeleteMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2089,9 +2089,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::DeleteMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2100,9 +2100,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::DeleteMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2111,9 +2111,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::DeleteMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2122,9 +2122,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::DeleteMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2133,9 +2133,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::DeleteMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2144,9 +2144,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyDeleteWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::DeleteMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2155,9 +2155,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PatchMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2166,9 +2166,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PatchMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2177,9 +2177,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::PatchMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2188,9 +2188,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PatchMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2199,9 +2199,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PatchMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2210,9 +2210,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PatchMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2221,9 +2221,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyPatchWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::PatchMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2232,9 +2232,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterInt" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::OptionsMethod, "/edit/123", function(Request $request, int $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2243,9 +2243,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterString" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::OptionsMethod, "/edit/123", function(Request $request, string $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame("123", $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame("123", $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2254,9 +2254,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterFloat" => [RouterContract::AnyMethod, "/edit/{id}", RouterContract::OptionsMethod, "/edit/123", function(Request $request, float $id): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/123", $request->pathInfo());
-				$this->assertSame(123.0, $id);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/123", $request->pathInfo());
+				self::assertSame(123.0, $id);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2265,9 +2265,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterBoolTrueInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::OptionsMethod, "/edit/1", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/1", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/1", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2276,9 +2276,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterBoolTrueString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::OptionsMethod, "/edit/true", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/true", $request->pathInfo());
-				$this->assertSame(true, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/true", $request->pathInfo());
+				self::assertSame(true, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2287,9 +2287,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterBoolFalseInt" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::OptionsMethod, "/edit/0", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/0", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/0", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2298,9 +2298,9 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalAnyOptionsWithParameterBoolFalseString" => [RouterContract::AnyMethod, "/edit/{confirmed}", RouterContract::OptionsMethod, "/edit/false", function(Request $request, bool $confirmed): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/edit/false", $request->pathInfo());
-				$this->assertSame(false, $confirmed);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/edit/false", $request->pathInfo());
+				self::assertSame(false, $confirmed);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2309,13 +2309,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithParametersDifferentOrderManyTypes" => [RouterContract::GetMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::GetMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2324,13 +2324,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalGetWithAllParametersDifferentOrderManyTypes" => [RouterContract::GetMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::GetMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2339,13 +2339,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPostWithParametersDifferentOrderManyTypes" => [RouterContract::PostMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::PostMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2354,13 +2354,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPostWithAllParametersDifferentOrderManyTypes" => [RouterContract::PostMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::PostMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2369,13 +2369,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPutWithParametersDifferentOrderManyTypes" => [RouterContract::PutMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::PutMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2384,13 +2384,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPutWithAllParametersDifferentOrderManyTypes" => [RouterContract::PutMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::PutMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2399,13 +2399,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalHeadWithParametersDifferentOrderManyTypes" => [RouterContract::HeadMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::HeadMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2414,13 +2414,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalHeadWithAllParametersDifferentOrderManyTypes" => [RouterContract::HeadMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::HeadMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2429,13 +2429,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalOptionsWithParametersDifferentOrderManyTypes" => [RouterContract::OptionsMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::OptionsMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2444,13 +2444,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalOptionsWithAllParametersDifferentOrderManyTypes" => [RouterContract::OptionsMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::OptionsMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2459,13 +2459,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalDeleteWithParametersDifferentOrderManyTypes" => [RouterContract::DeleteMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::DeleteMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2474,13 +2474,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalDeleteWithAllParametersDifferentOrderManyTypes" => [RouterContract::DeleteMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::DeleteMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2489,13 +2489,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPatchWithParametersDifferentOrderManyTypes" => [RouterContract::PatchMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::PatchMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2504,13 +2504,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalPatchWithAllParametersDifferentOrderManyTypes" => [RouterContract::PatchMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::PatchMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2519,13 +2519,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalConnectWithParametersDifferentOrderManyTypes" => [RouterContract::ConnectMethod, "/object/{type}/{id}/{action}/{property}/{value}", RouterContract::ConnectMethod, "/object/article/9563/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(9563, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/object/article/9563/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(9563, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2534,13 +2534,13 @@ class RouterTest extends TestCase
 				};
 			}],
 			"typicalConnectWithAllParametersDifferentOrderManyTypes" => [RouterContract::ConnectMethod, "/{type}/{id}/{action}/{property}/{value}", RouterContract::ConnectMethod, "/article/123456789/set/status/draft", function(Request $request, int $id, string $type, string $action, string $property, string $value): Response {
-				$this->assertInstanceOf(Request::class, $request);
-				$this->assertSame("/article/123456789/set/status/draft", $request->pathInfo());
-				$this->assertSame("article", $type);
-				$this->assertSame(123456789, $id);
-				$this->assertSame("set", $action);
-				$this->assertSame("status", $property);
-				$this->assertSame("draft", $value);
+				self::assertInstanceOf(Request::class, $request);
+				self::assertSame("/article/123456789/set/status/draft", $request->pathInfo());
+				self::assertSame("article", $type);
+				self::assertSame(123456789, $id);
+				self::assertSame("set", $action);
+				self::assertSame("status", $property);
+				self::assertSame("draft", $value);
 				return new class extends \Bead\Responses\AbstractResponse {
 					public function content(): string
 					{
@@ -2656,6 +2656,6 @@ class RouterTest extends TestCase
 		$routeCount = accumulate($routeCollection->getValue($router), $accumulateRoutes);
 		/** @noinspection PhpUnhandledExceptionInspection Should only throw an expected test exception. */
 		$router->register($route2, $route2Methods, function() {});
-		$this->assertGreaterThan($routeCount, accumulate($routeCollection->getValue($router), $accumulateRoutes), "The registration of the second route succeeded but didn't add to the routes colleciton in the router.");
+		self::assertGreaterThan($routeCount, accumulate($routeCollection->getValue($router), $accumulateRoutes), "The registration of the second route succeeded but didn't add to the routes colleciton in the router.");
 	}
 }

--- a/test/TranslatorTest.php
+++ b/test/TranslatorTest.php
@@ -24,21 +24,21 @@ class TranslatorTest extends TestCase
     {
         $translator = new Translator();
         $defaultLanguage = new ReflectionClassConstant(Translator::class, "DefaultLanguage");
-        $this->assertEquals($defaultLanguage->getValue(), $translator->language());
+        self::assertEquals($defaultLanguage->getValue(), $translator->language());
 
         $translator = new Translator("fr");
-        $this->assertEquals("fr", $translator->language());
+        self::assertEquals("fr", $translator->language());
     }
 
     public function testLanguage(): void
     {
         // ensure we can set a language
         $this->m_translator->setLanguage("en");
-        $this->assertEquals("en", $this->m_translator->language());
+        self::assertEquals("en", $this->m_translator->language());
 
         // ensure we can change language
         $this->m_translator->setLanguage("fr");
-        $this->assertEquals("fr", $this->m_translator->language());
+        self::assertEquals("fr", $this->m_translator->language());
     }
 
     public function testHasTranslation(): void
@@ -46,31 +46,31 @@ class TranslatorTest extends TestCase
         // ensure when there's no translations file we get false back
         $this->m_translator->setLanguage("this-language-does-not-exist");
         $actual = $this->m_translator->hasTranslation("nonsense");
-        $this->assertFalse($actual);
+        self::assertFalse($actual);
 
         // ensure when there's a translations available we get true
         $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
         $this->m_translator->setLanguage("fr");
         $actual = $this->m_translator->hasTranslation("door");
-        $this->assertTrue($actual);
+        self::assertTrue($actual);
 
         // ensure when there's a file loaded we get false back when there's no translation available
         $actual = $this->m_translator->hasTranslation("window");
-        $this->assertFalse($actual);
+        self::assertFalse($actual);
     }
 
     public function testSetLanguage(): void
     {
-        $this->assertNotEquals("fr", $this->m_translator->language());
+        self::assertNotEquals("fr", $this->m_translator->language());
         $this->m_translator->setLanguage("fr");
-        $this->assertEquals("fr", $this->m_translator->language());
+        self::assertEquals("fr", $this->m_translator->language());
     }
 
     public function testAddSearchPath(): void
     {
         $searchPath = realpath(__DIR__ . "/files/translations/");
         $this->m_translator->addSearchPath($searchPath);
-        $this->assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
+        self::assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
     }
 
     public function testTranslate(): void
@@ -78,34 +78,34 @@ class TranslatorTest extends TestCase
         // ensure when there's no translations file we get the original string back
         $this->m_translator->setLanguage("this-language-does-not-exist");
         $actual = $this->m_translator->translate("nonsense");
-        $this->assertEquals("nonsense", $actual);
+        self::assertEquals("nonsense", $actual);
 
         // ensure when there's a translations available we get it
         $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
         $this->m_translator->setLanguage("fr");
         $actual = $this->m_translator->translate("door");
-        $this->assertEquals("porte", $actual);
+        self::assertEquals("porte", $actual);
 
         // ensure when there's a file loaded we get the original string back when there's no translation available
         $actual = $this->m_translator->translate("window");
-        $this->assertEquals("window", $actual);
+        self::assertEquals("window", $actual);
     }
 
     public function testRemoveSearchPath(): void
     {
         $searchPath = realpath(__DIR__ . "/files/translations/");
         $this->m_translator->addSearchPath($searchPath);
-        $this->assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
+        self::assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
         $this->m_translator->removeSearchPath($searchPath);
-        $this->assertFalse(in_array($searchPath, $this->m_translator->searchPaths()));
+        self::assertFalse(in_array($searchPath, $this->m_translator->searchPaths()));
     }
 
     public function testClearSearchPaths(): void
     {
         $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
-        $this->assertNotEmpty($this->m_translator->searchPaths());
+        self::assertNotEmpty($this->m_translator->searchPaths());
         $this->m_translator->clearSearchPaths();
-        $this->assertEmpty($this->m_translator->searchPaths());
+        self::assertEmpty($this->m_translator->searchPaths());
     }
 
     public function testSearchPaths(): void
@@ -119,6 +119,6 @@ class TranslatorTest extends TestCase
             $this->m_translator->addSearchPath($searchPath);
         }
 
-        $this->assertEquals($searchPaths, $this->m_translator->searchPaths());
+        self::assertEquals($searchPaths, $this->m_translator->searchPaths());
     }
 }

--- a/test/UriSignerTest.php
+++ b/test/UriSignerTest.php
@@ -44,8 +44,8 @@ class UriSignerTest extends TestCase
 	public function testDefaultConstructor(): void
 	{
 		$signer = new UriSigner();
-		$this->assertEquals(UriSigner::DefaultAlgorithm, $signer->algorithm());
-		$this->assertEquals("", $signer->secret());
+		self::assertEquals(UriSigner::DefaultAlgorithm, $signer->algorithm());
+		self::assertEquals("", $signer->secret());
 	}
 
     /**
@@ -54,8 +54,8 @@ class UriSignerTest extends TestCase
 	public function testConstructorWithAlgorithm(): void
 	{
 		$signer = new UriSigner("md5");
-		$this->assertEquals("md5", $signer->algorithm());
-		$this->assertEquals("", $signer->secret());
+		self::assertEquals("md5", $signer->algorithm());
+		self::assertEquals("", $signer->secret());
 	}
 
     /**
@@ -81,7 +81,7 @@ class UriSignerTest extends TestCase
 
 		foreach ($algos as $algo) {
 			$this->m_signer->setAlgorithm($algo);
-			$this->assertEquals($algo, $this->m_signer->algorithm());
+			self::assertEquals($algo, $this->m_signer->algorithm());
 		}
 	}
 
@@ -90,11 +90,11 @@ class UriSignerTest extends TestCase
      */
     public function testAlgorithm(): void
     {
-        $this->assertEquals(UriSigner::DefaultAlgorithm, $this->m_signer->algorithm());
+        self::assertEquals(UriSigner::DefaultAlgorithm, $this->m_signer->algorithm());
 
         foreach (hash_hmac_algos() as $algo) {
             $this->m_signer->setAlgorithm($algo);
-            $this->assertEquals($algo, $this->m_signer->algorithm());
+            self::assertEquals($algo, $this->m_signer->algorithm());
         }
     }
 
@@ -103,13 +103,13 @@ class UriSignerTest extends TestCase
      */
 	public function testUsingSecret(): void
 	{
-		$this->assertNotEquals("some-other-secret", $this->m_signer->secret());
-		$this->assertEquals(self::Secret, $this->m_signer->secret());
+		self::assertNotEquals("some-other-secret", $this->m_signer->secret());
+		self::assertEquals(self::Secret, $this->m_signer->secret());
 		$actual = $this->m_signer->usingSecret("some-other-secret");
-		$this->assertInstanceOf(UriSigner::class, $actual);
-		$this->assertNotSame($this->m_signer, $actual);
-		$this->assertEquals(self::Secret, $this->m_signer->secret());
-		$this->assertEquals("some-other-secret", $actual->secret());
+		self::assertInstanceOf(UriSigner::class, $actual);
+		self::assertNotSame($this->m_signer, $actual);
+		self::assertEquals(self::Secret, $this->m_signer->secret());
+		self::assertEquals("some-other-secret", $actual->secret());
 	}
 
     /**
@@ -117,9 +117,9 @@ class UriSignerTest extends TestCase
      */
 	public function testSecret(): void
 	{
-		$this->assertEquals(self::Secret, $this->m_signer->secret());
+		self::assertEquals(self::Secret, $this->m_signer->secret());
 		$signer = $this->m_signer->usingSecret("some-other-secret");
-		$this->assertEquals("some-other-secret", $signer->secret());
+		self::assertEquals("some-other-secret", $signer->secret());
 	}
 
     /**
@@ -129,11 +129,11 @@ class UriSignerTest extends TestCase
     {
         $expected = "https://bead.framework/protected/uri?id=1&token=XF12jka8hbyHIofu6dSauioCHUIsfui754g&expires=1667232000&signature=850a5ede2b7af8a7354a443171aa67a90bddcbaf";
         $actual = $this->m_signer->sign("https://bead.framework/protected/uri", self::Parameters, self::ExpiresTimestamp);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
         $actual = $this->m_signer->sign("https://bead.framework/protected/uri", self::Parameters, new DateTime(self::ExpiresDateTime));
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
         $actual = $this->m_signer->sign("https://bead.framework/protected/uri", self::Parameters, new DateTimeImmutable(self::ExpiresDateTime));
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -142,7 +142,7 @@ class UriSignerTest extends TestCase
 	public function testVerify(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], PHP_INT_MAX);
-		$this->assertTrue($this->m_signer->verify($signed));
+		self::assertTrue($this->m_signer->verify($signed));
 	}
 
     /**
@@ -151,7 +151,7 @@ class UriSignerTest extends TestCase
 	public function testVerifyWithTimestamp(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp);
-		$this->assertTrue($this->m_signer->verify($signed, self::ExpiresTimestamp - 1));
+		self::assertTrue($this->m_signer->verify($signed, self::ExpiresTimestamp - 1));
 	}
 
     /**
@@ -160,7 +160,7 @@ class UriSignerTest extends TestCase
 	public function testVerifyWithDateTime(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp + (60 * 60 * 24 * 7));
-		$this->assertTrue($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
+		self::assertTrue($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
 	}
 
     /**
@@ -169,8 +169,8 @@ class UriSignerTest extends TestCase
 	public function testVerifyRejectsBadSignature(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], PHP_INT_MAX);
-		$this->assertFalse($this->m_signer->verify("{$signed}x"));
-		$this->assertFalse($this->m_signer->verify(substr($signed, 0, -1)));
+		self::assertFalse($this->m_signer->verify("{$signed}x"));
+		self::assertFalse($this->m_signer->verify(substr($signed, 0, -1)));
 	}
 
     /**
@@ -179,7 +179,7 @@ class UriSignerTest extends TestCase
 	public function testVerifyRejectsExpiredTimestamp(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp);
-		$this->assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp + 1));
+		self::assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp + 1));
 	}
 
     /**
@@ -188,7 +188,7 @@ class UriSignerTest extends TestCase
 	public function testVerifyRejectsExpiredDateTime(): void
 	{
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp - 1);
-		$this->assertFalse($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
+		self::assertFalse($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
 	}
 
     /**
@@ -198,7 +198,7 @@ class UriSignerTest extends TestCase
 	{
 		$now = time() - 1;
 		$signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], $now);
-		$this->assertFalse($this->m_signer->verify($signed));
+		self::assertFalse($this->m_signer->verify($signed));
 	}
 
     /**
@@ -213,8 +213,8 @@ class UriSignerTest extends TestCase
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], $expires);
         $modifiedExpires = self::ExpiresTimestamp + 1;
         $badSigned = str_replace("expires={$expires}", "expires={$modifiedExpires}", $signed);
-        $this->assertNotEquals($signed, $badSigned);
-        $this->assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp));
+        self::assertNotEquals($signed, $badSigned);
+        self::assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp));
     }
 
     /**
@@ -234,15 +234,15 @@ class UriSignerTest extends TestCase
 		// prove that the signed and the actual URIs are the same, bar the order of parameters
 		$signedParams = explode("&", parse_url($signed, PHP_URL_QUERY));
 		$actualParams = explode("&", parse_url($actual, PHP_URL_QUERY));
-		$this->assertEqualsCanonicalizing($signedParams, $actualParams);
+		self::assertEqualsCanonicalizing($signedParams, $actualParams);
 
 		foreach ([PHP_URL_SCHEME, PHP_URL_HOST, PHP_URL_PORT, PHP_URL_PATH, PHP_URL_USER, PHP_URL_PASS,] as $component) {
-			$this->assertEquals(parse_url($signed, $component), parse_url($actual, $component));
+			self::assertEquals(parse_url($signed, $component), parse_url($actual, $component));
 		}
 
-		$this->assertNotEquals($signed, $actual);
+		self::assertNotEquals($signed, $actual);
 
 		// prove that the different order causes verification to fail
-		$this->assertFalse($this->m_signer->verify($actual));
+		self::assertFalse($this->m_signer->verify($actual));
 	}
 }

--- a/test/Util/DaysTest.php
+++ b/test/Util/DaysTest.php
@@ -58,7 +58,7 @@ class DaysTest extends TestCase
 		}
 
 		$testObject = new Days($days);
-		$this->assertEquals($days, $testObject->days());
+		self::assertEquals($days, $testObject->days());
 	}
 
 	/**
@@ -86,7 +86,7 @@ class DaysTest extends TestCase
 	public function testDays(int $days): void
 	{
 		$testObject = new Days($days);
-		$this->assertEquals($days, $testObject->days());
+		self::assertEquals($days, $testObject->days());
 	}
 
 	/**
@@ -147,9 +147,9 @@ class DaysTest extends TestCase
 		
 		$days = new Days($initial);
 		$actual = $days->plus($add);
-		$this->assertNotSame($days, $actual);
-		$this->assertEquals($initial, $days->days());
-		$this->assertEquals($expected, $actual->days());
+		self::assertNotSame($days, $actual);
+		self::assertEquals($initial, $days->days());
+		self::assertEquals($expected, $actual->days());
 	}
 
 	/**
@@ -210,9 +210,9 @@ class DaysTest extends TestCase
 
 		$days = new Days($initial);
 		$actual = $days->minus($sub);
-		$this->assertNotSame($days, $actual);
-		$this->assertEquals($initial, $days->days());
-		$this->assertEquals($expected, $actual->days());
+		self::assertNotSame($days, $actual);
+		self::assertEquals($initial, $days->days());
+		self::assertEquals($expected, $actual->days());
 	}
 
 	/**
@@ -233,6 +233,6 @@ class DaysTest extends TestCase
 	 */
 	public function testInSeconds(int $days, int $expectedSeconds): void
 	{
-		$this->assertEquals($expectedSeconds, (new Days($days))->inSeconds());
+		self::assertEquals($expectedSeconds, (new Days($days))->inSeconds());
 	}
 }

--- a/test/Util/HoursTest.php
+++ b/test/Util/HoursTest.php
@@ -58,7 +58,7 @@ class HoursTest extends TestCase
 		}
 
 		$testObject = new Hours($hours);
-		$this->assertEquals($hours, $testObject->hours());
+		self::assertEquals($hours, $testObject->hours());
 	}
 
 	/**
@@ -86,7 +86,7 @@ class HoursTest extends TestCase
 	public function testHours(int $hours): void
 	{
 		$testObject = new Hours($hours);
-		$this->assertEquals($hours, $testObject->hours());
+		self::assertEquals($hours, $testObject->hours());
 	}
 
 	/**
@@ -147,9 +147,9 @@ class HoursTest extends TestCase
 
 		$hours = new Hours($initial);
 		$actual = $hours->plus($add);
-		$this->assertNotSame($hours, $actual);
-		$this->assertEquals($initial, $hours->hours());
-		$this->assertEquals($expected, $actual->hours());
+		self::assertNotSame($hours, $actual);
+		self::assertEquals($initial, $hours->hours());
+		self::assertEquals($expected, $actual->hours());
 	}
 
 	/**
@@ -210,9 +210,9 @@ class HoursTest extends TestCase
 
 		$hours = new Hours($initial);
 		$actual = $hours->minus($sub);
-		$this->assertNotSame($hours, $actual);
-		$this->assertEquals($initial, $hours->hours());
-		$this->assertEquals($expected, $actual->hours());
+		self::assertNotSame($hours, $actual);
+		self::assertEquals($initial, $hours->hours());
+		self::assertEquals($expected, $actual->hours());
 	}
 
 	/**
@@ -233,6 +233,6 @@ class HoursTest extends TestCase
 	 */
 	public function testInSeconds(int $hours, int $expectedSeconds): void
 	{
-		$this->assertEquals($expectedSeconds, (new Hours($hours))->inSeconds());
+		self::assertEquals($expectedSeconds, (new Hours($hours))->inSeconds());
 	}
 }

--- a/test/Util/MinutesTest.php
+++ b/test/Util/MinutesTest.php
@@ -58,7 +58,7 @@ class MinutesTest extends TestCase
 		}
 
 		$testObject = new Minutes($minutes);
-		$this->assertEquals($minutes, $testObject->minutes());
+		self::assertEquals($minutes, $testObject->minutes());
 	}
 
 	/**
@@ -86,7 +86,7 @@ class MinutesTest extends TestCase
 	public function testMinutes(int $minutes): void
 	{
 		$testObject = new Minutes($minutes);
-		$this->assertEquals($minutes, $testObject->minutes());
+		self::assertEquals($minutes, $testObject->minutes());
 	}
 
 	/**
@@ -147,9 +147,9 @@ class MinutesTest extends TestCase
 
 		$minutes = new Minutes($initial);
 		$actual = $minutes->plus($add);
-		$this->assertNotSame($minutes, $actual);
-		$this->assertEquals($initial, $minutes->minutes());
-		$this->assertEquals($expected, $actual->minutes());
+		self::assertNotSame($minutes, $actual);
+		self::assertEquals($initial, $minutes->minutes());
+		self::assertEquals($expected, $actual->minutes());
 	}
 
 	/**
@@ -210,9 +210,9 @@ class MinutesTest extends TestCase
 
 		$minutes = new Minutes($initial);
 		$actual = $minutes->minus($sub);
-		$this->assertNotSame($minutes, $actual);
-		$this->assertEquals($initial, $minutes->minutes());
-		$this->assertEquals($expected, $actual->minutes());
+		self::assertNotSame($minutes, $actual);
+		self::assertEquals($initial, $minutes->minutes());
+		self::assertEquals($expected, $actual->minutes());
 	}
 
 	/**
@@ -233,6 +233,6 @@ class MinutesTest extends TestCase
 	 */
 	public function testInSeconds(int $minutes, int $expectedSeconds): void
 	{
-		$this->assertEquals($expectedSeconds, (new Minutes($minutes))->inSeconds());
+		self::assertEquals($expectedSeconds, (new Minutes($minutes))->inSeconds());
 	}
 }

--- a/test/Util/ProcessTest.php
+++ b/test/Util/ProcessTest.php
@@ -66,11 +66,11 @@ class ProcessTest extends TestCase
 		if (!isset($timeout)) {
 			// set it to something we can reset from
 			Process::setCleanupTimeout(Process::DefaultCleanupTimeout + rand(1, 30));
-			$this->assertNotEquals(Process::DefaultCleanupTimeout, Process::cleanupTimeout(), "The cleanup timeout was not be set to a random non-default value.");
+			self::assertNotEquals(Process::DefaultCleanupTimeout, Process::cleanupTimeout(), "The cleanup timeout was not be set to a random non-default value.");
 		}
 
 		Process::setCleanupTimeout($timeout);
-		$this->assertEquals($timeout ?? Process::DefaultCleanupTimeout, Process::cleanupTimeout(), "The cleanup timeout was not (re)set successfully.");
+		self::assertEquals($timeout ?? Process::DefaultCleanupTimeout, Process::cleanupTimeout(), "The cleanup timeout was not (re)set successfully.");
 	}
 
 	/**
@@ -143,17 +143,17 @@ class ProcessTest extends TestCase
 		}
 
 		$process = new Process($command, $arguments, $workingDirectory, $outputNotifier, $errorNotifier);
-		$this->assertEquals($command, $process->command(), "Process was not constructed with correct command.");
-		$this->assertEquals($arguments, $process->arguments(), "Process was not constructed with correct arguments.");
-		$this->assertEquals($workingDirectory ?? getcwd(), $process->workingDirectory(), "Process was not constructed with correct working directory.");
+		self::assertEquals($command, $process->command(), "Process was not constructed with correct command.");
+		self::assertEquals($arguments, $process->arguments(), "Process was not constructed with correct arguments.");
+		self::assertEquals($workingDirectory ?? getcwd(), $process->workingDirectory(), "Process was not constructed with correct working directory.");
 
 		$property = new \ReflectionProperty($process, "m_outputNotifier");
 		$property->setAccessible(true);
-		$this->assertEquals($outputNotifier, $property->getValue($process), "Output notifier was not set correctly by constructor.");
+		self::assertEquals($outputNotifier, $property->getValue($process), "Output notifier was not set correctly by constructor.");
 
 		$property = new \ReflectionProperty($process, "m_errorNotifier");
 		$property->setAccessible(true);
-		$this->assertEquals($errorNotifier, $property->getValue($process), "Error notifier was not set correctly by constructor.");
+		self::assertEquals($errorNotifier, $property->getValue($process), "Error notifier was not set correctly by constructor.");
 	}
 
 	/**
@@ -190,7 +190,7 @@ class ProcessTest extends TestCase
 		
 		$process = new Process("");
 		$process->setCommand($command);
-		$this->assertEquals($command, $process->command(), "Command was not set successfully.");
+		self::assertEquals($command, $process->command(), "Command was not set successfully.");
 	}
 
 	/**
@@ -242,7 +242,7 @@ class ProcessTest extends TestCase
 
 		$process = new Process("");
 		$process->setArguments($args);
-		$this->assertEquals($args, $process->arguments(), "Arguments were not set successfully.");
+		self::assertEquals($args, $process->arguments(), "Arguments were not set successfully.");
 	}
 
 	/**
@@ -292,7 +292,7 @@ class ProcessTest extends TestCase
 
 		$process = new Process("");
 		$process->setWorkingDirectory($workingDirectory);
-		$this->assertEquals($workingDirectory ?? getcwd(), $process->workingDirectory(), "Working directory was not set successfully.");
+		self::assertEquals($workingDirectory ?? getcwd(), $process->workingDirectory(), "Working directory was not set successfully.");
 	}
 
 	/**
@@ -350,7 +350,7 @@ class ProcessTest extends TestCase
 
 		$process = new Process("");
 		$process->setEnvironment($env);
-		$this->assertEquals($env, $process->environment(), "Process environment was not set successfully.");
+		self::assertEquals($env, $process->environment(), "Process environment was not set successfully.");
 
 	}
 
@@ -417,12 +417,12 @@ class ProcessTest extends TestCase
 			}
 		);
 
-		$this->assertEquals($shouldStart, $process->start(), "The process did not start.");
-		$this->assertEquals($shouldStart, $process->isRunning(), "Process is not running.");
+		self::assertEquals($shouldStart, $process->start(), "The process did not start.");
+		self::assertEquals($shouldStart, $process->isRunning(), "Process is not running.");
 		$process->wait();
-		$this->assertEquals($expectedExitCode, $process->exitCode(), "The expected exit code was not produced.");
-		$this->assertEquals($expectedStdOut, $stdOut, "Process did not produce the expected output.");
-		$this->assertEquals($expectedStdErr, $stdErr, "Process did not produce the expected error output.");
+		self::assertEquals($expectedExitCode, $process->exitCode(), "The expected exit code was not produced.");
+		self::assertEquals($expectedStdOut, $stdOut, "Process did not produce the expected output.");
+		self::assertEquals($expectedStdErr, $stdErr, "Process did not produce the expected error output.");
 	}
 
 	/**
@@ -433,13 +433,13 @@ class ProcessTest extends TestCase
 		$process = new Process("php", ["-r", "'sleep(20);'",]);
 		$process->start();
 		usleep(500000);
-		$this->assertTrue($process->isRunning(), "Test process could not be started.");
+		self::assertTrue($process->isRunning(), "Test process could not be started.");
 		$stoppedAt = microtime(true);
 		$process->stop();
 		$process->wait(20);
-		$this->assertFalse($process->isRunning(), "Process was not stopped successfully.");
-		$this->assertLessThan(20, microtime(true) - $stoppedAt, "Process was not stopped successfully within the 20s it was expected to run.");
-		$this->assertNotEquals(0, $process->exitCode(), "Process should not have exited with exit code 0.");
+		self::assertFalse($process->isRunning(), "Process was not stopped successfully.");
+		self::assertLessThan(20, microtime(true) - $stoppedAt, "Process was not stopped successfully within the 20s it was expected to run.");
+		self::assertNotEquals(0, $process->exitCode(), "Process should not have exited with exit code 0.");
 	}
 
 	/**
@@ -464,9 +464,9 @@ class ProcessTest extends TestCase
 	{
 		$process = new Process($command, $args);
 		$process->start();
-		$this->assertIsInt($process->pid(), "Pid is not valid.");
+		self::assertIsInt($process->pid(), "Pid is not valid.");
 		$process->stop();
 		$process->wait();
-		$this->assertNull($process->pid(), "PID for terminated process is not null.");
+		self::assertNull($process->pid(), "PID for terminated process is not null.");
 	}
 }

--- a/test/Util/RetryTest.php
+++ b/test/Util/RetryTest.php
@@ -72,9 +72,9 @@ class RetryTest extends TestCase
 	{
 		$fn = self::createCallable();
 		$retry = new Retry($fn);
-		$this->assertSame($fn, $retry->retry());
-		$this->assertSame(1, $retry->maxRetries());
-		$this->assertNull($retry->exitCondition());
+		self::assertSame($fn, $retry->retry());
+		self::assertSame(1, $retry->maxRetries());
+		self::assertNull($retry->exitCondition());
 	}
 
 	/**
@@ -127,8 +127,8 @@ class RetryTest extends TestCase
 
 		$retry = new Retry(self::createCallable());
 		$actual = $retry->times($times);
-		$this->assertSame($retry, $actual);
-		$this->assertEquals($times, $actual->maxRetries());
+		self::assertSame($retry, $actual);
+		self::assertEquals($times, $actual->maxRetries());
 	}
 
 	/**
@@ -183,8 +183,8 @@ class RetryTest extends TestCase
 			->times($times);
 
 		$actual = $retry->until($predicate);
-		$this->assertSame($retry, $actual);
-		$this->assertSame($predicate, $retry->exitCondition());
+		self::assertSame($retry, $actual);
+		self::assertSame($predicate, $retry->exitCondition());
 	}
 
 	/**
@@ -219,8 +219,8 @@ class RetryTest extends TestCase
 			->times($times);
 
 		$retry();
-		$this->assertLessThanOrEqual($times, $retry->attemptsTaken());
-		$this->assertEquals($times, $actualTimes);
+		self::assertLessThanOrEqual($times, $retry->attemptsTaken());
+		self::assertEquals($times, $actualTimes);
 	}
 
 	/**
@@ -319,10 +319,10 @@ class RetryTest extends TestCase
 			->until($exitCondition);
 
 		$result = $retry();
-		$this->assertEquals($expectedTimes, $retry->attemptsTaken());
-		$this->assertLessThanOrEqual($maxTimes, $retry->attemptsTaken());
-		$this->assertEquals($expectedSuccess, $retry->succeeded());
-		$this->assertEquals($expectedResult, $result);
+		self::assertEquals($expectedTimes, $retry->attemptsTaken());
+		self::assertLessThanOrEqual($maxTimes, $retry->attemptsTaken());
+		self::assertEquals($expectedSuccess, $retry->succeeded());
+		self::assertEquals($expectedResult, $result);
 	}
 
 	/**
@@ -371,15 +371,15 @@ class RetryTest extends TestCase
 	{
 		$retry = (new Retry(self::createCallable()));
 		$retry();
-		$this->assertEquals(1, $retry->attemptsTaken());
+		self::assertEquals(1, $retry->attemptsTaken());
 
 		if (isset($exceptionClass)) {
 			$this->expectException($exceptionClass);
 		}
 
 		$retry->setMaxRetries($retries);
-		$this->assertEquals($retries, $retry->maxRetries());
-		$this->assertNull($retry->attemptsTaken());
+		self::assertEquals($retries, $retry->maxRetries());
+		self::assertNull($retry->attemptsTaken());
 	}
 
 	/**
@@ -406,7 +406,7 @@ class RetryTest extends TestCase
 		$retry = (new Retry(self::createCallable()))
 			->times($retries);
 
-		$this->assertEquals($retries, $retry->maxRetries());
+		self::assertEquals($retries, $retry->maxRetries());
 	}
 
 	/**
@@ -463,7 +463,7 @@ class RetryTest extends TestCase
 
 		$retry = new Retry(self::createCallable());
 		$retry->setRetry($callable);
-		$this->assertSame($callable, $retry->retry());
+		self::assertSame($callable, $retry->retry());
 	}
 
 	/**
@@ -496,7 +496,7 @@ class RetryTest extends TestCase
 	public function testRetry(callable $callable): void
 	{
 		$retry = new Retry($callable);
-		$this->assertSame($callable, $retry->retry());
+		self::assertSame($callable, $retry->retry());
 	}
 
 	/**
@@ -550,7 +550,7 @@ class RetryTest extends TestCase
 
 		$retry = new Retry(self::createCallable());
 		$retry->setExitCondition($exitCondition);
-		$this->assertSame($exitCondition, $retry->exitCondition());
+		self::assertSame($exitCondition, $retry->exitCondition());
 	}
 
 	/**
@@ -582,7 +582,7 @@ class RetryTest extends TestCase
 	{
 		$retry = (new Retry(self::createCallable()))
 			->until($exitCondition);
-		$this->assertSame($exitCondition, $retry->exitCondition());
+		self::assertSame($exitCondition, $retry->exitCondition());
 	}
 
 	/**
@@ -597,57 +597,57 @@ class RetryTest extends TestCase
 	{
 		// ensure it returns null on initialisation
 		$retry = new Retry(self::createCallable());
-		$this->assertNull($retry->attemptsTaken());
+		self::assertNull($retry->attemptsTaken());
 
 		// ensure it returns max when retry doesn't have an exit condition
 		$retry->times(1);
 		$retry();
-		$this->assertEquals(1, $retry->attemptsTaken());
+		self::assertEquals(1, $retry->attemptsTaken());
 
 		// ensure it gets reset when max changed
 		$retry->times(2);
-		$this->assertNull($retry->attemptsTaken());
+		self::assertNull($retry->attemptsTaken());
 		$retry();
-		$this->assertEquals(2, $retry->attemptsTaken());
+		self::assertEquals(2, $retry->attemptsTaken());
 
 		// ensure it gets reset when callable changed
 		$retry->setRetry(self::createCallable());
-		$this->assertNull($retry->attemptsTaken());
+		self::assertNull($retry->attemptsTaken());
 		$retry();
-		$this->assertEquals(2, $retry->attemptsTaken());
+		self::assertEquals(2, $retry->attemptsTaken());
 
 		// ensure it gets reset when exit condition changed
 		$retry->setExitCondition(fn($result): bool => true);
-		$this->assertNull($retry->attemptsTaken());
+		self::assertNull($retry->attemptsTaken());
 
 		// ensure it returns the correct value when the exit condition is in effect
 		$retry();
-		$this->assertEquals(1, $retry->attemptsTaken());
+		self::assertEquals(1, $retry->attemptsTaken());
 	}
 
 	public function testSucceeded(): void
 	{
 		// ensure it returns false on initialisation
 		$retry = new Retry(self::createCallable());
-		$this->assertFalse($retry->succeeded());
+		self::assertFalse($retry->succeeded());
 
 		// ensure it returns true when exit condition passes
 		$retry->setExitCondition(fn($result): bool => true);
 		$retry();
-		$this->assertTrue($retry->succeeded());
+		self::assertTrue($retry->succeeded());
 
 		// ensure it gets reset when max changed
 		$retry->times(2);
-		$this->assertFalse($retry->succeeded());
+		self::assertFalse($retry->succeeded());
 
 		// ensure it returns true when exit condition passes with greater max
 		$retry();
-		$this->assertEquals(1, $retry->attemptsTaken());
-		$this->assertTrue($retry->succeeded());
+		self::assertEquals(1, $retry->attemptsTaken());
+		self::assertTrue($retry->succeeded());
 
 		// ensure it gets reset when callable changed
 		$retry->setRetry(self::createCallable());
-		$this->assertFalse($retry->succeeded());
+		self::assertFalse($retry->succeeded());
 
 		// ensure it gets reset when exit condition changed
 		$retry->setExitCondition(function($result): bool {
@@ -661,11 +661,11 @@ class RetryTest extends TestCase
 			return $ret;
 		});
 		
-		$this->assertFalse($retry->succeeded());
+		self::assertFalse($retry->succeeded());
 
 		// ensure it returns the correct value when the exit condition returns true on a later attempt
 		$retry();
-		$this->assertEquals(2, $retry->attemptsTaken());
-		$this->assertTrue($retry->succeeded());
+		self::assertEquals(2, $retry->attemptsTaken());
+		self::assertTrue($retry->succeeded());
 	}
 }

--- a/test/Util/ScopeGuardTest.php
+++ b/test/Util/ScopeGuardTest.php
@@ -44,7 +44,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 
 		$guard = new ScopeGuard($closure);
 
-		$this->assertInstanceOf(ScopeGuard::class, $guard, "The ScopeGuard constructor did not create an instance of " . ScopeGuard::class . ".");
+		self::assertInstanceOf(ScopeGuard::class, $guard, "The ScopeGuard constructor did not create an instance of " . ScopeGuard::class . ".");
 	}
 
 	/**
@@ -59,7 +59,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 		});
 
 		$guard->invoke();
-		$this->assertTrue($called, "The scope guard closure was not called by invoke().");
+		self::assertTrue($called, "The scope guard closure was not called by invoke().");
 
 		$called1 = false;
 		$called2 = false;
@@ -73,8 +73,8 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 		});
 
 		$guard->invoke();
-		$this->assertTrue($called1, "The scope guard's initial closure was not called by invoke().");
-		$this->assertTrue($called2, "The scope guard's added closure was not called by invoke().");
+		self::assertTrue($called1, "The scope guard's initial closure was not called by invoke().");
+		self::assertTrue($called2, "The scope guard's added closure was not called by invoke().");
 
 		$called1 = false;
 		$called2 = false;
@@ -89,8 +89,8 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 
 		$cancelledGuard->cancel();
 		$cancelledGuard->invoke();
-		$this->assertFalse($called1, "The scope guard's initial closure was still called by invoke() after cancellation.");
-		$this->assertFalse($called2, "The scope guard's added closure was still called by invoke() after cancellation.");
+		self::assertFalse($called1, "The scope guard's initial closure was still called by invoke() after cancellation.");
+		self::assertFalse($called2, "The scope guard's added closure was still called by invoke() after cancellation.");
 	}
 
 	/**
@@ -106,7 +106,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			});
 		})();
 
-		$this->assertTrue($called, "The scope guard closure was not called on destruction.");
+		self::assertTrue($called, "The scope guard closure was not called on destruction.");
 
 		$called1 = false;
 		$called2 = false;
@@ -121,8 +121,8 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			});
 		})();
 
-		$this->assertTrue($called1, "The scope guard's initial closure was not called on destruction.");
-		$this->assertTrue($called2, "The scope guard's added closure was not called on destruction.");
+		self::assertTrue($called1, "The scope guard's initial closure was not called on destruction.");
+		self::assertTrue($called2, "The scope guard's added closure was not called on destruction.");
 	}
 
 	/**
@@ -141,7 +141,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			$guard->cancel();
 		})();
 
-		$this->assertTrue($notCalled, "The scope guard closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled, "The scope guard closure was still called on destruction after cancellation.");
 
 		$notCalled1 = true;
 		$notCalled2 = true;
@@ -158,8 +158,8 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			$guard->cancel();
 		})();
 
-		$this->assertTrue($notCalled1, "The scope guard's initial closure was still called on destruction after cancellation.");
-		$this->assertTrue($notCalled2, "The scope guard's added closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled1, "The scope guard's initial closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled2, "The scope guard's added closure was still called on destruction after cancellation.");
 
 		// test invoke() respets call to cancel()
 		$notCalled = true;
@@ -170,7 +170,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 
 		$guard->cancel();
 		$guard->invoke();
-		$this->assertTrue($notCalled, "The scope guard closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled, "The scope guard closure was still called on destruction after cancellation.");
 
 		$notCalled1 = true;
 		$notCalled2 = true;
@@ -185,8 +185,8 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 
 		$guard->cancel();
 		$guard->invoke();
-		$this->assertTrue($notCalled1, "The scope guard's initial closure was still called on destruction after cancellation.");
-		$this->assertTrue($notCalled2, "The scope guard's added closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled1, "The scope guard's initial closure was still called on destruction after cancellation.");
+		self::assertTrue($notCalled2, "The scope guard's added closure was still called on destruction after cancellation.");
 	}
 
 	/**
@@ -203,7 +203,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 		$guard->addClosure($closure);
 		$closuresMethod = new \ReflectionMethod($guard, "closures");
 		$closuresMethod->setAccessible(true);
-		$this->assertEquals(2, count($closuresMethod->invoke($guard)), "Scope guard did not have two closures after call to addClosure().");
+		self::assertEquals(2, count($closuresMethod->invoke($guard)), "Scope guard did not have two closures after call to addClosure().");
 	}
 
 	/**
@@ -222,7 +222,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			$guard->enable();
 		})();
 
-		$this->assertTrue($called, "The scope guard closure was not called on destruction.");
+		self::assertTrue($called, "The scope guard closure was not called on destruction.");
 
 		$called1 = false;
 		$called2 = false;
@@ -240,7 +240,7 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
 			$guard->enable();
 		})();
 
-		$this->assertTrue($called1, "The scope guard's initial closure was not called on destruction.");
-		$this->assertTrue($called2, "The scope guard's added closure was not called on destruction.");
+		self::assertTrue($called1, "The scope guard's initial closure was not called on destruction.");
+		self::assertTrue($called2, "The scope guard's added closure was not called on destruction.");
 	}
 }

--- a/test/Util/StopwatchTest.php
+++ b/test/Util/StopwatchTest.php
@@ -80,7 +80,7 @@ class StopwatchTest extends TestCase
         }
 
         $this->m_testStopwatch->setProcessName($name);
-        $this->assertEquals($name, $this->m_testStopwatch->processName());
+        self::assertEquals($name, $this->m_testStopwatch->processName());
     }
 
     /**
@@ -129,7 +129,7 @@ class StopwatchTest extends TestCase
             $this->markTestSkipped("Timer failed to stop");
         }
 
-        $this->assertEqualsWithDelta($duration,$this->m_testStopwatch->duration() * 1000, self::TestDurationTolerance, "Duration outside tolerance.");
+        self::assertEqualsWithDelta($duration,$this->m_testStopwatch->duration() * 1000, self::TestDurationTolerance, "Duration outside tolerance.");
     }
 
     /**
@@ -138,20 +138,20 @@ class StopwatchTest extends TestCase
     public function testStart(): void
     {
         $res = $this->m_testStopwatch->start();
-        $this->assertTrue($res, "failed to start timer");
+        self::assertTrue($res, "failed to start timer");
         $res = $this->m_testStopwatch->start();
-        $this->assertFalse($res, "should have received false when calling start() on a running timer");
+        self::assertFalse($res, "should have received false when calling start() on a running timer");
 
         if (false === $this->m_testStopwatch->stop()) {
             $this->markTestSkipped("Timer could not be stopped");
         }
 
         $res = $this->m_testStopwatch->start();
-        $this->assertFalse($res, "should have received false when calling start() on a finished timer");
+        self::assertFalse($res, "should have received false when calling start() on a finished timer");
         $this->m_testStopwatch->reset();
 
         $res = $this->m_testStopwatch->start();
-        $this->assertTrue($res, "failed to start a timer that had been reset");
+        self::assertTrue($res, "failed to start a timer that had been reset");
     }
 
     /**
@@ -239,7 +239,7 @@ class StopwatchTest extends TestCase
         $this->m_testStopwatch->addListener($event, $listener);
         $listenersProperty = new ReflectionProperty(Stopwatch::class, "m_listeners");
         $listenersProperty->setAccessible(true);
-        $this->assertEquals($listenersProperty->getValue($this->m_testStopwatch)[$event][0], $listener, "The array of listeners for event {$event} did not consist of the test listener.");
+        self::assertEquals($listenersProperty->getValue($this->m_testStopwatch)[$event][0], $listener, "The array of listeners for event {$event} did not consist of the test listener.");
     }
 
     /**
@@ -287,10 +287,10 @@ class StopwatchTest extends TestCase
             $this->markTestSkipped("failed to start timer");
         }
 
-        $this->assertEquals(1, $started["count"]);
-        $this->assertEquals(0, $stopped["count"]);
-        $this->assertEquals(0, $reset["count"]);
-        $this->assertEquals($this->m_testStopwatch->startTime(), $started["times"][0]);
+        self::assertEquals(1, $started["count"]);
+        self::assertEquals(0, $stopped["count"]);
+        self::assertEquals(0, $reset["count"]);
+        self::assertEquals($this->m_testStopwatch->startTime(), $started["times"][0]);
 
         $res = $this->m_testStopwatch->stop();
 
@@ -298,17 +298,17 @@ class StopwatchTest extends TestCase
             $this->markTestSkipped("failed to start timer");
         }
 
-        $this->assertEquals(1, $stopped["count"]);
-        $this->assertEquals(1, $stopped["count"]);
-        $this->assertEquals(0, $reset["count"]);
-        $this->assertEquals($this->m_testStopwatch->endTime(), $stopped["times"][0]);
-        $this->assertEquals($this->m_testStopwatch->duration(), $res);
-        $this->assertEquals($this->m_testStopwatch->duration(), $stopped["durations"][0]);
+        self::assertEquals(1, $stopped["count"]);
+        self::assertEquals(1, $stopped["count"]);
+        self::assertEquals(0, $reset["count"]);
+        self::assertEquals($this->m_testStopwatch->endTime(), $stopped["times"][0]);
+        self::assertEquals($this->m_testStopwatch->duration(), $res);
+        self::assertEquals($this->m_testStopwatch->duration(), $stopped["durations"][0]);
 
         $this->m_testStopwatch->reset();
 
-        $this->assertEquals(1, $stopped["count"]);
-        $this->assertEquals(1, $stopped["count"]);
-        $this->assertEquals(1, $reset["count"]);
+        self::assertEquals(1, $stopped["count"]);
+        self::assertEquals(1, $stopped["count"]);
+        self::assertEquals(1, $reset["count"]);
     }
 }

--- a/test/Validation/Rules/AlphaTest.php
+++ b/test/Validation/Rules/AlphaTest.php
@@ -88,6 +88,6 @@ class AlphaTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/AlphanumericTest.php
+++ b/test/Validation/Rules/AlphanumericTest.php
@@ -122,6 +122,6 @@ class AlphanumericTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/EmailTest.php
+++ b/test/Validation/Rules/EmailTest.php
@@ -83,6 +83,6 @@ class EmailTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/FilledTest.php
+++ b/test/Validation/Rules/FilledTest.php
@@ -103,6 +103,6 @@ class FilledTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IntegerTest.php
+++ b/test/Validation/Rules/IntegerTest.php
@@ -97,7 +97,7 @@ class IntegerTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
     /**
      * Data provider for testConvert().
@@ -139,7 +139,7 @@ class IntegerTest extends RuleTestCase
     {
         /** @var Integer $rule */
         $rule = $this->ruleInstance();
-        $this->assertTrue($rule->passes("field", $data));
-        $this->assertSame($expected, $rule->convert($data));
+        self::assertTrue($rule->passes("field", $data));
+        self::assertSame($expected, $rule->convert($data));
     }
 }

--- a/test/Validation/Rules/IpTest.php
+++ b/test/Validation/Rules/IpTest.php
@@ -120,6 +120,6 @@ class IpTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IsArrayTest.php
+++ b/test/Validation/Rules/IsArrayTest.php
@@ -113,6 +113,6 @@ class IsArrayTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IsBooleanTest.php
+++ b/test/Validation/Rules/IsBooleanTest.php
@@ -161,6 +161,6 @@ class IsBooleanTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IsFalseTest.php
+++ b/test/Validation/Rules/IsFalseTest.php
@@ -161,6 +161,6 @@ class IsFalseTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IsStringTest.php
+++ b/test/Validation/Rules/IsStringTest.php
@@ -79,6 +79,6 @@ class IsStringTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/IsTrueTest.php
+++ b/test/Validation/Rules/IsTrueTest.php
@@ -124,6 +124,6 @@ class IsTrueTest extends RuleTestCase
         }
 
         $rule = $this->ruleInstance();
-        $this->assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
+        self::assertSame($shouldPass, $rule->passes($field, $data), "The rule did not provide the expected result from passes().");
     }
 }

--- a/test/Validation/Rules/NullableTest.php
+++ b/test/Validation/Rules/NullableTest.php
@@ -90,7 +90,7 @@ class NullableTest extends TestCase
 		}
 
 		// rule always passes, our test expectations are handled by Mockery
-		$this->assertTrue($rule->passes("field", $value));
+		self::assertTrue($rule->passes("field", $value));
 	}
 
 	/**
@@ -104,9 +104,9 @@ class NullableTest extends TestCase
 		$rule = $this->createNullableRule();
 
 		if ($isNull) {
-			$this->assertEquals(null, $rule->convert($value));
+			self::assertEquals(null, $rule->convert($value));
 		} else {
-			$this->assertEquals($value, $rule->convert($value));
+			self::assertEquals($value, $rule->convert($value));
 		}
 	}
 
@@ -125,6 +125,6 @@ class NullableTest extends TestCase
 		$rule = $this->createNullableRule();
 		$this->m_validator->shouldIgnoreMissing();
 		$rule->passes("field", $value);
-		$this->assertEquals("", $rule->message("field"));
+		self::assertEquals("", $rule->message("field"));
 	}
 }

--- a/test/Validation/Rules/TestsKnowsValidatorTrait.php
+++ b/test/Validation/Rules/TestsKnowsValidatorTrait.php
@@ -19,7 +19,7 @@ trait TestsKnowsValidatorTrait
 	public function testValidator(): void
 	{
 		$rule = self::createValidatorAwareRule();
-		$this->assertNull($rule->validator());
+		self::assertNull($rule->validator());
 
 		$validator = Mockery::mock(Validator::class);
 		$rule->setValidator($validator);


### PR DESCRIPTION
- updated AssertsCommonExceptionProperties to have static methods and constraints on importing classes for methods used
- all assertions now use self:: not $this->