### PR TITLE
BEAD-98 Updated SessionNotFoundException

### DIFF
--- a/src/Exceptions/Session/SessionNotFoundException.php
+++ b/src/Exceptions/Session/SessionNotFoundException.php
@@ -10,7 +10,7 @@ use Throwable;
 class SessionNotFoundException extends SessionException
 {
     /** @var string The ID of the session that was not found. */
-    private string $m_id;
+    private string $m_sessionId;
 
     /**
      * Initialise a new instance of the exception.
@@ -23,15 +23,15 @@ class SessionNotFoundException extends SessionException
     public function __construct(string $id, string $message = "", int $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->m_id = $id;
+        $this->m_sessionId = $id;
     }
 
     /**
      * Fetch the ID of the missing session.
      * @return string The ID.
      */
-    public function getId(): string
+    public function getSessionId(): string
     {
-        return $this->m_id;
+        return $this->m_sessionId;
     }
 }

--- a/test/Exceptions/Session/SessionNotFoundExceptionTest.php
+++ b/test/Exceptions/Session/SessionNotFoundExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BeadTests\Exceptions\Session;
+
+use Bead\Exceptions\Session\SessionNotFoundException;
+use BeadTests\Exceptions\AssertsCommonExceptionProperties;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class SessionNotFoundExceptionTest extends TestCase
+{
+    use AssertsCommonExceptionProperties;
+
+    /** @var string The session ID to test with. */
+    private const TestId = "fca40c6b-660a-4ddf-935a-31adb2aca09e";
+
+    /** Ensure the ID of the missing session can be set in the exception constructor. */
+    public function testConstructor(): void
+    {
+        $exception = new SessionNotFoundException(self::TestId);
+        self::assertEquals(self::TestId, $exception->getSessionId());
+        self::assertCode($exception, 0);
+        self::assertMessage($exception, "");
+        self::assertPrevious($exception, null);
+    }
+
+    /** Ensure we can set an exception code in the constructor. */
+    public function testConstructorWithCode(): void
+    {
+        $exception = new SessionNotFoundException(self::TestId, code: 42);
+        self::assertEquals(self::TestId, $exception->getSessionId());
+        self::assertCode($exception, 42);
+        self::assertMessage($exception, "");
+        self::assertPrevious($exception, null);
+    }
+
+    /** Ensure we can set an message in the constructor. */
+    public function testConstructorWithMessage(): void
+    {
+        $exception = new SessionNotFoundException(self::TestId, message: "The meaning of life.");
+        self::assertEquals(self::TestId, $exception->getSessionId());
+        self::assertCode($exception, 0);
+        self::assertMessage($exception, "The meaning of life.");
+        self::assertPrevious($exception, null);
+    }
+
+    /** Ensure we can set a previous exception in the constructor. */
+    public function testConstructorWithPrevious(): void
+    {
+        $previous = new RuntimeException();
+        $exception = new SessionNotFoundException(self::TestId, previous: $previous);
+        self::assertEquals(self::TestId, $exception->getSessionId());
+        self::assertCode($exception, 0);
+        self::assertMessage($exception, "");
+        self::assertPrevious($exception, $previous);
+    }
+}


### PR DESCRIPTION
- renamed getId() to getSessionId() for consistency
- unit test