### PR TITLE
BEAD-95 Updated SessionDestroyedException

### DIFF
--- a/src/Exceptions/Session/SessionDestroyedException.php
+++ b/src/Exceptions/Session/SessionDestroyedException.php
@@ -10,7 +10,7 @@ use Throwable;
 class SessionDestroyedException extends SessionException
 {
     /** @var string The ID of the session that has been destroyed. */
-    private string $m_id;
+    private string $m_sessionId;
 
     /**
      * Initialise a new instance of the exception.
@@ -23,15 +23,15 @@ class SessionDestroyedException extends SessionException
     public function __construct(string $id, string $message = "", int $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->m_id = $id;
+        $this->m_sessionId = $id;
     }
 
     /**
      * Fetch the ID of the destroyed session.
      * @return string The ID.
      */
-    public function getId(): string
+    public function getSessionId(): string
     {
-        return $this->m_id;
+        return $this->m_sessionId;
     }
 }

--- a/test/Exceptions/Session/SessionDestroyedExceptionTest.php
+++ b/test/Exceptions/Session/SessionDestroyedExceptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Exceptions\Session;
+
+use Bead\Exceptions\Session\SessionDestroyedException;
+use BeadTests\Exceptions\AssertsCommonExceptionProperties;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SessionDestroyedExceptionTest extends TestCase
+{
+	use AssertsCommonExceptionProperties;
+
+	/** @var string The session ID to test with. */
+	private const TestId = "fca40c6b-660a-4ddf-935a-31adb2aca09e";
+
+	/** Ensure the session ID can be set in the exception constructor. */
+	public function testConstructor(): void
+	{
+		$exception = new SessionDestroyedException(self::TestId);
+		self::assertEquals(self::TestId, $exception->getSessionId());
+		self::assertCode($exception, 0);
+		self::assertMessage($exception, "");
+		self::assertPrevious($exception, null);
+	}
+
+	/** Ensure we can set an exception code in the constructor. */
+	public function testConstructorWithCode(): void
+	{
+		$exception = new SessionDestroyedException(self::TestId, code: 42);
+		self::assertEquals(self::TestId, $exception->getSessionId());
+		self::assertCode($exception, 42);
+		self::assertMessage($exception, "");
+		self::assertPrevious($exception, null);
+	}
+
+	/** Ensure we can set an message in the constructor. */
+	public function testConstructorWithMessage(): void
+	{
+		$exception = new SessionDestroyedException(self::TestId, message: "The meaning of life.");
+		self::assertEquals(self::TestId, $exception->getSessionId());
+		self::assertCode($exception, 0);
+		self::assertMessage($exception, "The meaning of life.");
+		self::assertPrevious($exception, null);
+	}
+
+	/** Ensure we can set a previous exception in the constructor. */
+	public function testConstructorWithPrevious(): void
+	{
+		$previous = new RuntimeException();
+		$exception = new SessionDestroyedException(self::TestId, previous: $previous);
+		self::assertEquals(self::TestId, $exception->getSessionId());
+		self::assertCode($exception, 0);
+		self::assertMessage($exception, "");
+		self::assertPrevious($exception, $previous);
+	}
+}


### PR DESCRIPTION
- renamed getId() to getSessionId() for consistency
- unit test