### PR TITLE
BEAD-81 Use TestCase mock management instead of uopz_*_function()

### DIFF
--- a/test/Concurrent/SharedMemoryTest.php
+++ b/test/Concurrent/SharedMemoryTest.php
@@ -44,10 +44,6 @@ class SharedMemoryTest extends TestCase
      */
     public function tearDown(): void
     {
-        if (!is_null(uopz_get_return("rand"))) {
-            uopz_unset_return("rand");
-        }
-
         $this->m_memory->delete();
 
         /** @var SharedMemory $memory */
@@ -59,6 +55,7 @@ class SharedMemoryTest extends TestCase
         }
 
         unset($this->m_memory, $this->m_memories);
+        parent::tearDown();
     }
 
     public function testCreateWithId(): void
@@ -81,15 +78,17 @@ class SharedMemoryTest extends TestCase
         $newId = 0x80808080;
         $called = false;
 
-        uopz_set_return("rand", function() use ($existingId, $newId, &$called): int
-        {
-            if (!$called) {
-                $called = true;
-                return $existingId;
-            }
+        $this->mockFunction("rand",
+            function() use ($existingId, $newId, &$called): int
+            {
+                if (!$called) {
+                    $called = true;
+                    return $existingId;
+                }
 
-            return $newId;
-        }, true);
+                return $newId;
+            }
+        );
 
         $memory = SharedMemory::create(10);
         $this->m_memories[] = $memory;

--- a/test/Database/ManyToManyTest.php
+++ b/test/Database/ManyToManyTest.php
@@ -9,97 +9,96 @@ use BeadTests\Framework\TestCase;
 use Bead\Database\Model;
 use Mockery;
 
-use function uopz_set_return;
-use function uopz_clear_return;
-
 class ManyToManyTest extends TestCase
 {
-    private Application $m_app;
-    private Connection $m_db;
-    private Model $m_local;
-    private ManyToMany $m_relation;
+    private Application $app;
+
+    private Connection $db;
+
+    private Model $local;
+
+    private ManyToMany $relation;
 
     public function setUp(): void
     {
-        $this->m_db = Mockery::mock(Connection::class);
-        $this->m_app = Mockery::mock(Application::class);
-        uopz_set_return(Application::class, "instance", $this->m_app);
-
-        $this->m_app->shouldReceive("database")->andReturn($this->m_db);
-        $this->m_local = new class extends Model
+        $this->db = Mockery::mock(Connection::class);
+        $this->app = Mockery::mock(Application::class);
+        $this->mockMethod(Application::class, "instance", $this->app);
+        $this->app->shouldReceive("database")->andReturn($this->db);
+        $this->local = new class extends Model
         {
             protected static string $table = "Foo";
         };
 
-        $this->m_relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", "pk_on_foo", "pk_on_bar");
+        $this->relation = new ManyToMany($this->local, "Bar", "FooBarLink", "foo_id", "bar_id", "pk_on_foo", "pk_on_bar");
     }
 
     public function tearDown(): void
     {
-        uopz_unset_return(Application::class, "instance");
-        unset($this->m_relation, $this->m_app, $this->m_db, $this->m_local);
+        unset($this->relation, $this->app, $this->db, $this->local);
+        parent::tearDown();
     }
 
     public function testConstructorDefaults(): void
     {
-        $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id");
+        $relation = new ManyToMany($this->local, "Bar", "FooBarLink", "foo_id", "bar_id");
         self::assertEquals("id", $relation->localKey());
         self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testConstructorWithLocalKey(): void
     {
-        $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_id");
+        $relation = new ManyToMany($this->local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_id");
         self::assertEquals("the_id", $relation->localKey());
         self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testConstructorWithRelatedKey(): void
     {
-        $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", null, "the_related_id");
+        $relation = new ManyToMany($this->local, "Bar", "FooBarLink", "foo_id", "bar_id", null, "the_related_id");
         self::assertEquals("id", $relation->localKey());
         self::assertEquals("the_related_id", $relation->relatedKey());
     }
 
     public function testConstructorWithLocalAndRelatedKey(): void
     {
-        $relation = new ManyToMany($this->m_local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_local_id", "the_related_id");
+        $relation = new ManyToMany($this->local, "Bar", "FooBarLink", "foo_id", "bar_id", "the_local_id", "the_related_id");
         self::assertEquals("the_local_id", $relation->localKey());
         self::assertEquals("the_related_id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        self::assertSame("pk_on_foo", $this->m_relation->localKey());
+        self::assertSame("pk_on_foo", $this->relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        self::assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->local, $this->relation->localModel());
     }
 
     public function testPivotLocalKey(): void
     {
-        self::assertEquals("foo_id", $this->m_relation->pivotLocalKey());
+        self::assertEquals("foo_id", $this->relation->pivotLocalKey());
     }
 
     public function testPivotRelatedKey(): void
     {
-        self::assertEquals("bar_id", $this->m_relation->pivotRelatedKey());
+        self::assertEquals("bar_id", $this->relation->pivotRelatedKey());
     }
 
     public function testPivotModel(): void
     {
-        self::assertEquals("FooBarLink", $this->m_relation->pivotModel());
+        self::assertEquals("FooBarLink", $this->relation->pivotModel());
     }
 
     public function testRelatedKey(): void
     {
-        self::assertEquals("pk_on_bar", $this->m_relation->relatedKey());
+        self::assertEquals("pk_on_bar", $this->relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->relation->relatedModel());
     }
 }

--- a/test/Database/ManyToOneTest.php
+++ b/test/Database/ManyToOneTest.php
@@ -11,58 +11,60 @@ use Mockery;
 
 class ManyToOneTest extends TestCase
 {
-    private Application $m_app;
-    private Connection $m_db;
-    private Model $m_local;
-    private ManyToOne $m_relation;
+    private Application $app;
+
+    private Connection $db;
+
+    private Model $local;
+
+    private ManyToOne $relation;
 
     public function setUp(): void
     {
-        $this->m_db = Mockery::mock(Connection::class);
-        $this->m_app = Mockery::mock(Application::class);
-        uopz_set_return(Application::class, "instance", $this->m_app);
-
-        $this->m_app->shouldReceive("database")->andReturn($this->m_db);
-        $this->m_local = new class extends Model
+        $this->db = Mockery::mock(Connection::class);
+        $this->app = Mockery::mock(Application::class);
+        $this->mockMethod(Application::class, "instance", $this->app);
+        $this->app->shouldReceive("database")->andReturn($this->db);
+        $this->local = new class extends Model
         {
             protected static string $table = "Foo";
         };
 
-        $this->m_relation = new ManyToOne($this->m_local, "Bar", "id", "bar_id");
+        $this->relation = new ManyToOne($this->local, "Bar", "id", "bar_id");
     }
 
     public function tearDown(): void
     {
-        uopz_unset_return(Application::class, "instance");
-        unset($this->m_relation, $this->m_app, $this->m_db, $this->m_local);
+        unset($this->relation, $this->app, $this->db, $this->local);
+        parent::tearDown();
     }
 
     public function testConstructor(): void
     {
-        $relation = new ManyToOne($this->m_local, "Bar", "id", "bar_id");
-        self::assertSame($this->m_local, $relation->localModel());
-        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        $relation = new ManyToOne($this->local, "Bar", "id", "bar_id");
+        self::assertSame($this->local, $relation->localModel());
+        self::assertEquals("Bar", $this->relation->relatedModel());
         self::assertEquals("bar_id", $relation->localKey());
         self::assertEquals("id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        self::assertSame("bar_id", $this->m_relation->localKey());
+        self::assertSame("bar_id", $this->relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        self::assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->local, $this->relation->localModel());
     }
 
     public function testRelatedKey(): void
     {
-        self::assertEquals("id", $this->m_relation->relatedKey());
+        self::assertEquals("id", $this->relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->relation->relatedModel());
     }
 }

--- a/test/Database/OneToManyTest.php
+++ b/test/Database/OneToManyTest.php
@@ -11,58 +11,60 @@ use Mockery;
 
 class OneToManyTest extends TestCase
 {
-    private Application $m_app;
-    private Connection $m_db;
-    private Model $m_local;
-    private OneToMany $m_relation;
+    private Application $app;
+
+    private Connection $db;
+
+    private Model $local;
+
+    private OneToMany $relation;
 
     public function setUp(): void
     {
-        $this->m_db = Mockery::mock(Connection::class);
-        $this->m_app = Mockery::mock(Application::class);
-        uopz_set_return(Application::class, "instance", $this->m_app);
-
-        $this->m_app->shouldReceive("database")->andReturn($this->m_db);
-        $this->m_local = new class extends Model
+        $this->db = Mockery::mock(Connection::class);
+        $this->app = Mockery::mock(Application::class);
+        $this->mockMethod(Application::class, "instance", $this->app);
+        $this->app->shouldReceive("database")->andReturn($this->db);
+        $this->local = new class extends Model
         {
             protected static string $table = "Foo";
         };
 
-        $this->m_relation = new OneToMany($this->m_local, "Bar", "foo_id", "id");
+        $this->relation = new OneToMany($this->local, "Bar", "foo_id", "id");
     }
 
     public function tearDown(): void
     {
-        uopz_unset_return(Application::class, "instance");
-        unset($this->m_relation, $this->m_app, $this->m_db, $this->m_local);
+        unset($this->relation, $this->app, $this->db, $this->local);
+        parent::tearDown();
     }
 
     public function testConstructor(): void
     {
-        $relation = new OneToMany($this->m_local, "Bar", "foo_id", "id");
-        self::assertSame($this->m_local, $relation->localModel());
-        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        $relation = new OneToMany($this->local, "Bar", "foo_id", "id");
+        self::assertSame($this->local, $relation->localModel());
+        self::assertEquals("Bar", $this->relation->relatedModel());
         self::assertEquals("id", $relation->localKey());
         self::assertEquals("foo_id", $relation->relatedKey());
     }
 
     public function testLocalKey(): void
     {
-        self::assertSame("id", $this->m_relation->localKey());
+        self::assertSame("id", $this->relation->localKey());
     }
 
     public function testLocalModel(): void
     {
-        self::assertSame($this->m_local, $this->m_relation->localModel());
+        self::assertSame($this->local, $this->relation->localModel());
     }
 
     public function testRelatedKey(): void
     {
-        self::assertEquals("foo_id", $this->m_relation->relatedKey());
+        self::assertEquals("foo_id", $this->relation->relatedKey());
     }
 
     public function testRelatedModel(): void
     {
-        self::assertEquals("Bar", $this->m_relation->relatedModel());
+        self::assertEquals("Bar", $this->relation->relatedModel());
     }
 }

--- a/test/Database/QueryBuilderTest.php
+++ b/test/Database/QueryBuilderTest.php
@@ -26,16 +26,14 @@ use Mockery;
 use PDO;
 use TypeError;
 
-use function uopz_set_return;
-use function uopz_unset_return;
-
 /**
  * Test the query builder class.
  */
 class QueryBuilderTest extends TestCase
 {
-    private ?Application $m_application;
-    private ?Connection $m_defaultConnection;
+    private ?Application $application;
+
+    private ?Connection $defaultConnection;
 
     /**
      * Sets up for every test.
@@ -44,25 +42,18 @@ class QueryBuilderTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->m_application = Mockery::mock(Application::class);
-        $this->m_defaultConnection = Mockery::mock(Connection::class);
-
-        uopz_set_return(Application::class, "instance", $this->m_application);
-
-        $this->m_application->shouldReceive("database")
-            ->andReturn($this->m_defaultConnection);
+        $this->application = Mockery::mock(Application::class);
+        $this->defaultConnection = Mockery::mock(Connection::class);
+        $this->mockMethod(Application::class, "instance", $this->application);
+        $this->application->shouldReceive("database")
+            ->andReturn($this->defaultConnection);
     }
 
     public function tearDown(): void
     {
-        uopz_unset_return(Application::class, "instance");
-
-        unset(
-            $this->m_application,
-            $this->m_defaultConnection
-        );
-
+        unset($this->application, $this->defaultConnection);
         Mockery::close();
+        parent::tearDown();
     }
 
     /**
@@ -111,15 +102,15 @@ class QueryBuilderTest extends TestCase
     public function testDefaultConstructor(): void
     {
         $builder = new QueryBuilder();
-        $this->m_application->shouldHaveReceived("database")->once();
-        self::assertSame($this->m_defaultConnection, $builder->connection());
+        $this->application->shouldHaveReceived("database")->once();
+        self::assertSame($this->defaultConnection, $builder->connection());
     }
 
     public function testConstructorWithConnection(): void
     {
         $connection = Mockery::mock(Connection::class);
         $builder = new QueryBuilder($connection);
-        $this->m_application->shouldNotHaveReceived("database");
+        $this->application->shouldNotHaveReceived("database");
         self::assertSame($connection, $builder->connection());
     }
 
@@ -161,7 +152,7 @@ class QueryBuilderTest extends TestCase
     {
         $builder = new QueryBuilder();
         $connection = Mockery::mock(PDO::class);
-        self::assertSame($this->m_defaultConnection, $builder->connection());
+        self::assertSame($this->defaultConnection, $builder->connection());
         $builder->setConnection($connection);
         self::assertSame($connection, $builder->connection());
     }

--- a/test/Helpers/I18nTest.php
+++ b/test/Helpers/I18nTest.php
@@ -48,12 +48,12 @@ final class I18nTest extends TestCase
 			}
 		};
 
-		uopz_set_return(Application::class, "instance", $this->m_app);
+        $this->mockMethod(Application::class, "instance", $this->m_app);
 	}
 
 	public function tearDown(): void
 	{
-		uopz_unset_return(Application::class, "instance");
+        parent::tearDown();
 		Mockery::close();
 	}
 
@@ -96,7 +96,7 @@ final class I18nTest extends TestCase
 
 	public function testTrWithoutApp(): void
 	{
-		uopz_set_return(Application::class, "instance", null);
+        $this->mockMethod(Application::class, "instance", null);
 
 		self::assertEquals("foo", tr("foo"));
 		self::assertEquals("foo bar", tr("foo %1", __FILE__, __LINE__, "bar"));

--- a/test/Helpers/StrTest.php
+++ b/test/Helpers/StrTest.php
@@ -19,19 +19,9 @@ use function Bead\Helpers\Str\random;
 use function range;
 use function strlen;
 use function strspn;
-use function uopz_get_return;
-use function uopz_set_return;
-use function uopz_unset_return;
 
 final class StrTest extends TestCase
 {
-	public function tearDown(): void
-	{
-		if (!is_null(uopz_get_return("random_bytes"))) {
-			uopz_unset_return("random_bytes");
-		}
-	}
-
 	public function dataForTestCamelToSnake(): iterable
 	{
 		yield from [
@@ -346,13 +336,11 @@ final class StrTest extends TestCase
     /** Ensure random() */
 	public function testRandomIsCryptoSecure(): void
 	{
-		uopz_set_return(
-			"random_bytes",
+        $this->mockFunction("random_bytes",
 			function(int $length): string
 			{
 				throw new Exception("random_bytes() is not available.");
-			},
-			true
+			}
 		);
 
 		$this->expectException(RuntimeException::class);

--- a/test/Responses/NaivelySendsContentTest.php
+++ b/test/Responses/NaivelySendsContentTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace BeadTests\Responses;
 
 use Bead\Responses\NaivelySendsContent;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 final class NaivelySendsContentTest extends TestCase
 {
@@ -22,17 +22,6 @@ final class NaivelySendsContentTest extends TestCase
 
 	/** @var int The expected HTTP status code for the response. */
 	public const TestStatusCode = 200;
-
-	public function tearDown(): void
-	{
-		if (uopz_get_return('header')) {
-			uopz_unset_return('header');
-		}
-
-		if (uopz_get_return('http_response_code')) {
-			uopz_unset_return('http_response_code');
-		}
-	}
 
 	/** Create an anonymous object that imports the trait under test. */
 	private function createInstance(): mixed
@@ -75,28 +64,24 @@ final class NaivelySendsContentTest extends TestCase
 		$expectedHeaders[] = "content-type: " . self::TestContentType;
 		$test = $this;
 
-		uopz_set_return(
-			'header',
+        $this->mockFunction('header',
 			function (string $header, bool $replace) use (&$expectedHeaders, $test)
 			{
 				$test->assertTrue($replace);
 				$idx = array_search($header, $expectedHeaders);
 				$test->assertIsInt($idx, "Unexpected header '{$header}' generated.");
 				array_splice($expectedHeaders, $idx, 1);
-			},
-			true
+			}
 		);
 
 		$httpResponseCodeCalled = 0;
 
-		uopz_set_return(
-			'http_response_code',
+        $this->mockFunction('http_response_code',
 			function (int $code) use (&$httpResponseCodeCalled, $test)
 			{
 				++$httpResponseCodeCalled;
 				$test->assertEquals(NaivelySendsContentTest::TestStatusCode, $code);
-			},
-			true
+			}
 		);
 
 		ob_start();

--- a/test/Responses/SendsHeadersTest.php
+++ b/test/Responses/SendsHeadersTest.php
@@ -4,7 +4,7 @@ namespace BeadTests\Responses;
 
 use Bead\Responses\SendsHeaders;
 use Bead\Testing\XRay;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 final class SendsHeadersTest extends TestCase
 {
@@ -32,13 +32,6 @@ final class SendsHeadersTest extends TestCase
         };
     }
 
-    public function tearDown(): void
-    {
-        if (uopz_get_return('header')) {
-            uopz_unset_return('header');
-        }
-    }
-
     /** Ensure we send the expected headers. */
     public function testSendHeaders(): void
     {
@@ -51,16 +44,14 @@ final class SendsHeadersTest extends TestCase
         $expectedHeaders[] = "content-type: text/plain";
         $test = $this;
 
-        uopz_set_return(
-            'header',
+        $this->mockFunction('header',
             function (string $header, bool $replace) use (&$expectedHeaders, $test)
             {
                 $test->assertTrue($replace);
                 $idx = array_search($header, $expectedHeaders);
                 $test->assertIsInt($idx, "Unexpected header '{$header}' generated.");
                 array_splice($expectedHeaders, $idx, 1);
-            },
-            true
+            }
         );
 
         $instance = new XRay($this->createInstance());


### PR DESCRIPTION
- manage method mocks
- update all uses of uopz_*_function() in tests to use managed mocks in TestCase base class