### PR TITLE
BEAD-103 unit test coverage testing static x ray

### DIFF
--- a/src/Testing/StaticXRay.php
+++ b/src/Testing/StaticXRay.php
@@ -40,7 +40,7 @@ class StaticXRay
     private array $m_xRayedMethods = [];
 
     /** @var string[] Cache of methods that cannot be resolved. */
-    private array $m_unresolvedMethods = [];
+    private array $m_unresolvableMethods = [];
 
     /** @var string[] Cache of resolved public static properties. */
     private array $m_publicProperties = [];
@@ -51,7 +51,7 @@ class StaticXRay
     private array $m_xRayedProperties = [];
 
     /** @var string[] Cache of properties that cannot be resolved. */
-    private array $m_unresolvedProperties = [];
+    private array $m_unresolvableProperties = [];
 
     /**
      * Initialise a new static x-ray for a named class.
@@ -78,7 +78,7 @@ class StaticXRay
      */
     protected function resolveMethod(string $method): void
     {
-        if (in_array($method, $this->m_publicMethods) || in_array($method, $this->m_unresolvedMethods) || isset($this->m_xRayedMethods[$method])) {
+        if (in_array($method, $this->m_publicMethods) || in_array($method, $this->m_unresolvableMethods) || isset($this->m_xRayedMethods[$method])) {
             return;
         }
 
@@ -89,7 +89,7 @@ class StaticXRay
         }
 
         if (!isset($reflector) || !$reflector->isStatic()) {
-            $this->m_unresolvedMethods[] = $method;
+            $this->m_unresolvableMethods[] = $method;
             return;
         }
 
@@ -109,7 +109,7 @@ class StaticXRay
      */
     protected function resolveProperty(string $property): void
     {
-        if (in_array($property, $this->m_publicProperties) || in_array($property, $this->m_unresolvedProperties) || isset($this->m_xRayedProperties[$property])) {
+        if (in_array($property, $this->m_publicProperties) || in_array($property, $this->m_unresolvableProperties) || isset($this->m_xRayedProperties[$property])) {
             return;
         }
 
@@ -120,7 +120,7 @@ class StaticXRay
         }
 
         if (!isset($reflector) || !$reflector->isStatic()) {
-            $this->m_unresolvedProperties[] = $property;
+            $this->m_unresolvableProperties[] = $property;
             return;
         }
 
@@ -260,6 +260,7 @@ class StaticXRay
             return $this->className()::$$property = $value;
         } else if ($this->isXRayedStaticProperty($property)) {
             $this->m_xRayedProperties[$property]->setValue(null, $value);
+            return $this->m_xRayedProperties[$property]->getValue(null);
         }
 
         throw new LogicException("Static property '{$property}' does not exist on object of class '{$this->m_subjectReflector->getName()}'.");

--- a/test/Testing/StaticXRayTest.php
+++ b/test/Testing/StaticXRayTest.php
@@ -3,11 +3,13 @@
 namespace BeadTests\Testing;
 
 use BadMethodCallException;
+use Bead\Exceptions\Testing\StaticXRayException;
+use Bead\Testing\StaticXRay;
 use BeadTests\Framework\CallTracker;
 use BeadTests\Framework\TestCase;
-use Bead\Testing\StaticXRay;
 use LogicException;
 
+// TODO test invoking the static xrayed method throws BadMethodCall
 class StaticXRayTest extends TestCase
 {
     public const StringArg = "hitch-hiker";
@@ -22,33 +24,36 @@ class StaticXRayTest extends TestCase
 
         $testObject = new class($this->m_tracker)
         {
-            private static CallTracker $m_tracker;
-            private static string $m_privateStaticProperty = "private-static-property";
+            private static CallTracker $callTracker;
+            private static string $privateStaticProperty = "private-static-property";
             public static string $publicStaticProperty = "public-static-property";
 
-            private string $m_privateProperty = "private-property";
+            private string $privateProperty = "private-property";
             public string $publicProperty = "public-property";
 
             public function __construct(CallTracker $tracker)
             {
-                self::$m_tracker = $tracker;
+                self::$callTracker = $tracker;
+                // we reset these every time the object is created so that they don't persist between tests
+                self::$privateStaticProperty = "private-static-property";
+                self::$publicStaticProperty = "public-static-property";
             }
 
             private static function privateStaticMethod(): string
             {
-                self::$m_tracker->increment();
+                self::$callTracker->increment();
                 return "private-static-method";
             }
 
             public static function publicStaticMethod(): string
             {
-                self::$m_tracker->increment();
+                self::$callTracker->increment();
                 return "public-static-method";
             }
 
             private static function privateStaticMethodWithArgs(string $arg1, int $arg2): string
             {
-                self::$m_tracker->increment();
+                self::$callTracker->increment();
                 StaticXRayTest::assertEquals(StaticXRayTest::StringArg, $arg1);
                 StaticXRayTest::assertEquals(StaticXRayTest::IntArg, $arg2);
                 return "{$arg1} {$arg2}";
@@ -56,7 +61,7 @@ class StaticXRayTest extends TestCase
 
             public static function publicStaticMethodWithArgs(string $arg1, int $arg2): string
             {
-                self::$m_tracker->increment();
+                self::$callTracker->increment();
                 StaticXRayTest::assertEquals(StaticXRayTest::StringArg, $arg1);
                 StaticXRayTest::assertEquals(StaticXRayTest::IntArg, $arg2);
                 return "{$arg1} {$arg2}";
@@ -90,12 +95,12 @@ class StaticXRayTest extends TestCase
             public static function __callStatic(string $method, array $args): string
             {
                 if ("staticMagicMethod" === $method) {
-                    self::$m_tracker->increment();
+                    self::$callTracker->increment();
                     return "magic-method";
                 }
 
                 if ("staticMagicMethodWithArgs" === $method) {
-                    self::$m_tracker->increment();
+                    self::$callTracker->increment();
                     return "{$args[0]} {$args[1]}";
                 }
 
@@ -104,6 +109,13 @@ class StaticXRayTest extends TestCase
         };
 
         $this->m_xRay = new StaticXRay(get_class($testObject));
+    }
+
+    public function testConstructorThrows(): void
+    {
+        self::expectException(StaticXRayException::class);
+        self::expectExceptionMessage("The class 'non-existent-class' does not exist.");
+        $xRay = new StaticXRay("non-existent-class");
     }
 
     public function testPublicStaticProperty(): void
@@ -115,9 +127,9 @@ class StaticXRayTest extends TestCase
 
     public function testXRayedStaticProperty(): void
     {
-        self::assertFalse($this->m_xRay->isPublicStaticProperty("m_privateStaticProperty"));
-        self::assertTrue($this->m_xRay->isXRayedStaticProperty("m_privateStaticProperty"));
-        self::assertEquals("private-static-property", $this->m_xRay->m_privateStaticProperty);
+        self::assertFalse($this->m_xRay->isPublicStaticProperty("privateStaticProperty"));
+        self::assertTrue($this->m_xRay->isXRayedStaticProperty("privateStaticProperty"));
+        self::assertEquals("private-static-property", $this->m_xRay->privateStaticProperty);
     }
 
     public function testPublicProperty(): void
@@ -131,9 +143,9 @@ class StaticXRayTest extends TestCase
     public function testPrivateProperty(): void
     {
         self::expectException(LogicException::class);
-        self::assertFalse($this->m_xRay->isPublicStaticProperty("m_privateProperty"));
-        self::assertFalse($this->m_xRay->isXRayedStaticProperty("m_privateProperty"));
-        self::assertEquals("", $this->m_xRay->m_privateProperty);
+        self::assertFalse($this->m_xRay->isPublicStaticProperty("privateProperty"));
+        self::assertFalse($this->m_xRay->isXRayedStaticProperty("privateProperty"));
+        self::assertEquals("", $this->m_xRay->privateProperty);
     }
 
     public function testNonExistentProperty(): void
@@ -150,6 +162,37 @@ class StaticXRayTest extends TestCase
         self::assertFalse($this->m_xRay->isPublicStaticProperty(""));
         self::assertFalse($this->m_xRay->isXRayedStaticProperty(""));
         self::assertEquals("", $this->m_xRay->{""});
+    }
+
+    public function testSetPublicStaticProperty(): void
+    {
+        if ("other-value" === $this->m_xRay->className()::$publicStaticProperty) {
+            self::markTestSkipped("The public static property already has the value we want to change it to.");
+        }
+
+        $this->m_xRay->publicStaticProperty = "other-value";
+        self::assertEquals("other-value", $this->m_xRay->className()::$publicStaticProperty);
+    }
+
+    public function testSetPrivateStaticProperty(): void
+    {
+        if ("other-value" === $this->m_xRay->privateStaticProperty) {
+            self::markTestSkipped("The private static property already has the value we want to change it to.");
+        }
+
+        $this->m_xRay->privateStaticProperty = "other-value";
+        self::assertEquals("other-value", $this->m_xRay->privateStaticProperty);
+    }
+
+    public function testSetNonExistentProperty(): void
+    {
+        if ($this->m_xRay->isXRayedStaticProperty("nonExistentProperty") || $this->m_xRay->isPublicStaticProperty("nonExistentProperty")) {
+            self::markTestSkipped("The property 'nonExistentProperty' must not exist for this test to be valid.");
+        }
+
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage("Static property 'nonExistentProperty' does not exist on object of class '" . $this->m_xRay->className() . "'.");
+        $this->m_xRay->nonExistentProperty = "other-value";
     }
 
     public function testPublicStaticMethod(): void
@@ -245,7 +288,7 @@ class StaticXRayTest extends TestCase
         self::expectException(BadMethodCallException::class);
         self::assertFalse($this->m_xRay->isPublicStaticMethod("nonExistentMethod"));
         self::assertFalse($this->m_xRay->isXRayedStaticMethod("nonExistentMethod"));
-        self::assertEquals("", $this->m_xRay->nonExistentMethod());
+        $this->m_xRay->nonExistentMethod();
     }
 
     public function testEmptyMethod(): void
@@ -253,6 +296,20 @@ class StaticXRayTest extends TestCase
         self::expectException(BadMethodCallException::class);
         self::assertFalse($this->m_xRay->isPublicStaticMethod(""));
         self::assertFalse($this->m_xRay->isXRayedStaticMethod(""));
-        self::assertEquals("", $this->m_xRay->{""}());
+        $this->m_xRay->{""}();
+    }
+
+    public function testNonExistentMethodNoCallStatic(): void
+    {
+        $object = (object)[];
+        $xray = new StaticXRay(get_class($object));
+
+        if ($xray->isPublicStaticMethod("__callStatic") || $xray->isPublicStaticMethod("nonExistentMethod") || $xray->isXRayedStaticMethod("nonExistentMethod")) {
+            self::markTestSkipped("The methods nonExistentMethod and __callStatic must not exist on the test object for this test to be valid.");
+        }
+
+        self::expectException(BadMethodCallException::class);
+        self::expectExceptionMessage("Static method 'nonExistentMethod' does not exist on class '" . get_class($object) . "'.");
+        $xray->nonExistentMethod();
     }
 }


### PR DESCRIPTION
Updated `StaticXRay`

- full coverage in unit test
- fixed bug in `__set()` that would always throw for x-rayed static properties