### PR TITLE
BEAD-31 router dependency injection

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -214,13 +214,13 @@ class Router implements RouterContract
                 continue;
             }
 
-            # if the handler wants an instance of a service bound into the service container, provide it
+            // if the handler wants an instance of a service bound into the service container, provide it
             if ($app?->has($type->getName())) {
                 $handlerArguments[] = $app->get($type->getName());
                 continue;
             }
 
-            # otherwise, look for the argument in those extracted from the route
+            // otherwise, look for the argument in those extracted from the route
             if (!array_key_exists($parameter->getName(), $routeArguments)) {
                 if (!$parameter->isOptional()) {
                     throw new LogicException("Can't call handler for route parameter \${$parameter->getName()} is not optional and does not have a value in the route definition.");

--- a/test/RouterTest.php
+++ b/test/RouterTest.php
@@ -3682,7 +3682,7 @@ class RouterTest extends TestCase
 
         $expectedResponse = Mockery::mock(Response::class);
 
-        $handler = function(Logger $injectedLog) use ($log, $expectedResponse): Response {
+        $handler = function (Logger $injectedLog) use ($log, $expectedResponse): Response {
             RouterTest::assertSame($log, $injectedLog);
             return $expectedResponse;
         };

--- a/test/RouterTest.php
+++ b/test/RouterTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace BeadTests;
 
+use Bead\Application;
+use Bead\Contracts\Logger;
 use Bead\Contracts\Response;
 use Bead\Exceptions\ConflictingRouteException;
 use Bead\Exceptions\DuplicateRouteParameterNameException;
@@ -21,8 +23,8 @@ use Bead\Request;
 use Bead\Testing\XRay;
 use Closure;
 use InvalidArgumentException;
+use Mockery;
 use ReflectionProperty;
-use TypeError;
 
 use function Bead\Helpers\Iterable\accumulate;
 
@@ -36,21 +38,21 @@ class RouterTest extends TestCase
      *
      * This is useful for asserting that the handler was called when a request was routed.
      */
-    private static int $s_nullStaticRouteHandlerCallCount = 0;
+    private static int $nullStaticRouteHandlerCallCount = 0;
 
     /**
      * @var int The number of times the nullRouteHandler was called during a test.
      *
      * This is useful for asserting that the handler was called when a request was routed.
      */
-    private int $m_nullRouteHandlerCallCount = 0;
+    private int $nullRouteHandlerCallCount = 0;
 
     /**
      * Route handler that does nothing except increment a call counter.
      */
     public static function nullStaticRouteHandler(): void
     {
-        ++self::$s_nullStaticRouteHandlerCallCount;
+        ++self::$nullStaticRouteHandlerCallCount;
     }
 
     /**
@@ -58,7 +60,7 @@ class RouterTest extends TestCase
      */
     public function nullRouteHandler(): void
     {
-        ++$this->m_nullRouteHandlerCallCount;
+        ++$this->nullRouteHandlerCallCount;
     }
 
     /**
@@ -2566,7 +2568,7 @@ class RouterTest extends TestCase
      *
      * @return array[] The test data.
      */
-    public function dataForTestRoute(): array
+    public function dataForTestRoute1(): array
     {
         return [
             "typicalGetWithNoParameters" => [RouterContract::GetMethod, "/home", RouterContract::GetMethod, "/home", function (Request $request): Response {
@@ -3635,7 +3637,7 @@ class RouterTest extends TestCase
     /**
      * Test for Router::route()
      *
-     * @dataProvider dataForTestRoute
+     * @dataProvider dataForTestRoute1
      *
      * @param string|array<string> $routeMethods The HTTP methods to define for the test route.
      * @param string $route The test route.
@@ -3646,18 +3648,49 @@ class RouterTest extends TestCase
      *
      * @noinspection PhpDocMissingThrowsInspection Only exceptions thrown will be exptected test exceptions.
      */
-    public function testRoute($routeMethods, string $route, string $requestMethod, string $requestPath, ?Closure $handler, ?string $exceptionClass = null): void
+    public function testRoute1($routeMethods, string $route, string $requestMethod, string $requestPath, ?Closure $handler, ?string $exceptionClass = null): void
     {
         if (isset($exceptionClass)) {
             $this->expectException($exceptionClass);
         }
 
-        $router = new XRay(new Router());
+        $router = new Router();
         /** @noinspection PhpUnhandledExceptionInspection Should never throw with test data. */
         $router->register($route, $routeMethods, $handler);
         $request = self::makeRequest($requestPath, $requestMethod);
         /** @noinspection PhpUnhandledExceptionInspection Should only throw expected test exceptions. */
         $router->route($request);
+    }
+
+    /** Ensure dependencies can be injected into route parameters from the service container. */
+    public function testRoute2(): void
+    {
+        $log = Mockery::mock(Logger::class);
+        $app = Mockery::mock(Application::class);
+        $this->mockMethod(Application::class, "instance", $app);
+
+        $app->shouldReceive("has")
+            ->once()
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->shouldReceive("get")
+            ->once()
+            ->with(Logger::class)
+            ->andReturn($log);
+
+
+        $expectedResponse = Mockery::mock(Response::class);
+
+        $handler = function(Logger $injectedLog) use ($log, $expectedResponse): Response {
+            RouterTest::assertSame($log, $injectedLog);
+            return $expectedResponse;
+        };
+
+        $router = new Router();
+        $router->registerGet("/", $handler);
+        $actualResponse = $router->route(self::makeRequest("/"));
+        self::assertSame($expectedResponse, $actualResponse);
     }
 
     /**


### PR DESCRIPTION
Allows dependencies to be injected into route handlers if an appropriate object has been bound into the service container. This facilitates testing by enabling mocks to be provided directly to route handlers, rather than having to mock the service container and its bound services.