### PR TITLE
BEAD-153 Make Plugins Optional

### DIFF
--- a/src/WebApplication.php
+++ b/src/WebApplication.php
@@ -441,13 +441,16 @@ class WebApplication extends Application
      * Plugins are loaded from the default plugins path. All valid plugins found are loaded and instantiated. The
      * error log will contain details of any plugins that failed to load.
      *
-     * @return bool true if the plugins path was successfully scanned for plugins, false otherwise.
      * @throws InvalidPluginsDirectoryException if the plugins path can't be read for some reason.
      * @throws InvalidPluginException if the plugins path can't be read for some reason.
      */
-    protected function loadPlugins(): bool
+    protected function loadPlugins(): void
     {
         static $s_done = false;
+
+        if (!$this->config("app.plugins.enabled", false)) {
+            return;
+        }
 
         if (!$s_done) {
             $info = new SplFileInfo("{$this->rootDir()}/{$this->pluginsDirectory()}");
@@ -489,8 +492,6 @@ class WebApplication extends Application
             $s_done = true;
             $this->emitEvent("application.pluginsloaded");
         }
-
-        return true;
     }
 
     /**

--- a/test/WebApplicationTest.php
+++ b/test/WebApplicationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests;
+
+use Bead\Database\Connection;
+use Bead\Facades\Session;
+use Bead\Testing\XRay;
+use Bead\Application;
+use Bead\WebApplication;
+use BeadTests\Framework\TestCase;
+use ReflectionProperty;
+
+class WebApplicationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->mockFunction("setcookie", true);
+        $this->mockMethod(WebApplication::class, "csrf", "csrf-token");
+    }
+
+    public function tearDown(): void
+    {
+        $instance = new ReflectionProperty(Application::class, "s_instance");
+        $instance->setAccessible(true);
+        $instance->setValue(null);
+
+        $session = new ReflectionProperty(Session::class, "session");
+        $session->setAccessible(true);
+        $session->setValue(null);
+
+        parent::tearDown();
+    }
+
+    private static function makeTestWebApplication(): WebApplication
+    {
+        return new class extends WebApplication {
+            public function __construct()
+            {
+            }
+        };
+    }
+
+    /** Ensure plugins are not loaded when the config has disabled them. */
+    public function testLoadPlugins1(): void
+    {
+        $loadPluginCalled = false;
+
+        $this->mockMethod(WebApplication::class, "loadPlugin", function () use (&$loadPluginCalled): void {
+            $loadPluginCalled = true;
+            TestCase::fail("loadPlugin() should not be called.");
+        });
+
+        $app = new XRay($this->makeTestWebApplication());
+        $app->loadPlugins();
+        self::assertFalse($loadPluginCalled);
+    }
+
+    /** Ensure plugins are not loaded by default. */
+    public function testLoadPlugins2(): void
+    {
+        $loadPluginCalled = false;
+
+        $this->mockMethod(WebApplication::class, "loadPlugin", function () use (&$loadPluginCalled): void {
+            $loadPluginCalled = true;
+            TestCase::fail("loadPlugin() should not be called.");
+        });
+
+        $app = new XRay($this->makeTestWebApplication());
+        $app->loadPlugins();
+        self::assertFalse($loadPluginCalled);
+    }
+}

--- a/test/smoke/config/app.php
+++ b/test/smoke/config/app.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-	"debugmode"=> true,
+    "debugmode"=> true,
     "plugins" => [
         "enabled" => false,
     ]

--- a/test/smoke/config/app.php
+++ b/test/smoke/config/app.php
@@ -2,4 +2,7 @@
 
 return [
 	"debugmode"=> true,
+    "plugins" => [
+        "enabled" => false,
+    ]
 ];


### PR DESCRIPTION
The framework is moving away from plugins as a common thing, so make them opt-in (by enabling them in the config) so that the app does not throw if it doesn't find a plugins directory when no plugins are required.