### PR TITLE
BEAD-164 Work around FileLogger destructor randomly throwing an Error exception.

### DIFF
--- a/src/Logging/FileLogger.php
+++ b/src/Logging/FileLogger.php
@@ -10,13 +10,11 @@ use RuntimeException;
 use SplFileInfo;
 use SplFileObject;
 use Stringable;
-
 use Throwable;
+
 use function Bead\Helpers\Str\build;
 
-/**
- * Log messages to a named file.
- */
+/** Log messages to a named file. */
 class FileLogger extends PsrAbstractLogger implements LoggerContract
 {
     use HasLogLevel;

--- a/src/Logging/FileLogger.php
+++ b/src/Logging/FileLogger.php
@@ -11,6 +11,7 @@ use SplFileInfo;
 use SplFileObject;
 use Stringable;
 
+use Throwable;
 use function Bead\Helpers\Str\build;
 
 /**
@@ -30,7 +31,7 @@ class FileLogger extends PsrAbstractLogger implements LoggerContract
     /** @var string The name of the log file. */
     private string $fileName;
 
-    /** @var SplFileObject The open log file. */
+    /** @var SplFileObject|null The open log file. */
     private ?SplFileObject $file;
 
     /**
@@ -59,7 +60,11 @@ class FileLogger extends PsrAbstractLogger implements LoggerContract
     /** Flush the log write buffer to the file on destruction. */
     public function __destruct()
     {
-        $this->file->fflush();
+        try {
+            $this->file?->fflush();
+        } catch (Throwable) {
+            // do nothing - we've tried to flush the log file, but if it hasn't worked there's not much else we can do
+        }
     }
 
     /**


### PR DESCRIPTION
Work around call to `SplFileObject::fflush()` in `FileLogger` destructor randomly throwing an Error exception.