### PR TITLE
BEAD-171 Update binders to make them more reusable through inheritance.

### DIFF
--- a/src/Core/Binders/Database.php
+++ b/src/Core/Binders/Database.php
@@ -9,6 +9,7 @@ use Bead\Core\Application;
 use Bead\Database\Connection;
 use Bead\Exceptions\InvalidConfigurationException;
 use Bead\Exceptions\ServiceAlreadyBoundException;
+use PDOException;
 
 use function array_key_exists;
 use function is_array;
@@ -140,6 +141,8 @@ class Database implements Binder
      * Helper to create a connection.
      *
      * Abstracted primarily to make createDatabaseConnection() testable.
+     *
+     * @throws PDOException
      */
     private static function connection(string $dsn, string $user, string $password): Connection
     {
@@ -151,6 +154,8 @@ class Database implements Binder
      *
      * @param array $config The database configuration.
      * @return Connection
+     * @throws InvalidConfigurationException if the database configuration is not valid.
+     * @throws PDOException if the database connection cannot be created.
      */
     protected static function createDatabaseConnection(array $config): Connection
     {
@@ -172,6 +177,7 @@ class Database implements Binder
      * @throws InvalidConfigurationException if the database configuration is not valid.
      * @throws ServiceAlreadyBoundException if a database connection has already been bound into the application service
      * container.
+     * @throws PDOException if the database connection cannot be created.
      */
     public function bindServices(Application $app): void
     {

--- a/src/Core/Binders/Logger.php
+++ b/src/Core/Binders/Logger.php
@@ -39,13 +39,12 @@ class Logger implements BinderContract
      * In either case, the resulting path must not have any `..` path components in it.
      *
      * @param array $config The log configuration.
-     * @param string $root The application root directory, to which any relative log file path will be appended.
      * @return FileLogger The generated logger.
      * @throws InvalidConfigurationException if the file logger configuration is not present, doesn't contain a path or
      * contains an invalid path.
      * @throws FileLoggerException if creating the logger fails.
      */
-    protected static function fileLogger(array $config, string $root): FileLogger
+    protected static function createFileLogger(array $config): FileLogger
     {
         if (!array_key_exists("file", $config)) {
             throw new InvalidConfigurationException("log.file", "Expected file configuration, none found");
@@ -58,7 +57,7 @@ class Logger implements BinderContract
         $path = $config["file"]["path"];
 
         if (!str_starts_with($path, "/")) {
-            $path = "{$root}/{$path}";
+            $path = Application::instance()->rootDir() . "/{$path}";
         }
 
         if (".." === $path || str_contains($path, "/../") || str_starts_with($path, "../") || str_ends_with($path, "/..")) {
@@ -68,14 +67,31 @@ class Logger implements BinderContract
         return new FileLogger($path, $config["file"]["flags"] ?? FileLogger::FlagAppend);
     }
 
-     /**
-      *  Bind services into the container.
-      *
-      * @param Application $app The application service container into which to bind services.
-      * @throws InvalidConfigurationException if no log driver or an unrecognised driver is found in the configuration.
-      * @throws ServiceAlreadyBoundException if a logger is already bound.
-      * @throws FileLoggerException if creating the logger fails.
-      */
+    /**
+     * Create the Logger instance to bind to the contract in the service container.
+     *
+     * @param array $config
+     * @return LoggerContract
+     */
+    protected static function createLogger(array $config): LoggerContract
+    {
+        return match ($config["driver"]) {
+            "file" => self::createFileLogger($config),
+            "stdout" => new StandardOutputLogger(),
+            "stderr" => new StandardErrorLogger(),
+            "null" => new NullLogger(),
+            default => throw new InvalidConfigurationException("log.driver", "Expected recognised log driver, found \"{$config["driver"]}\""),
+        };
+    }
+
+    /**
+     *  Bind services into the container.
+     *
+     * @param Application $app The application service container into which to bind services.
+     * @throws InvalidConfigurationException if no log driver or an unrecognised driver is found in the configuration.
+     * @throws ServiceAlreadyBoundException if a logger is already bound.
+     * @throws FileLoggerException if creating the logger fails.
+     */
     public function bindServices(Application $app): void
     {
         $config = $app->config("log", self::DefaultConfig);
@@ -85,25 +101,6 @@ class Logger implements BinderContract
             throw new InvalidConfigurationException("log.driver", "Expected log driver, none found");
         }
 
-        switch ($driver) {
-            case "file":
-                $app->bindService(LoggerContract::class, self::fileLogger($config, $app->rootDir()));
-                break;
-
-            case "stdout":
-                $app->bindService(LoggerContract::class, new StandardOutputLogger());
-                break;
-
-            case "stderr":
-                $app->bindService(LoggerContract::class, new StandardErrorLogger());
-                break;
-
-            case "null":
-                $app->bindService(LoggerContract::class, new NullLogger());
-                break;
-
-            default:
-                throw new InvalidConfigurationException("log.driver", "Expected recognised log driver, found \"{$driver}\"");
-        }
+        $app->bindService(LoggerContract::class, static::createLogger($config));
     }
 }

--- a/src/Core/Binders/Translator.php
+++ b/src/Core/Binders/Translator.php
@@ -22,6 +22,7 @@ class Translator implements BinderContract
      *
      * @param Application $app
      * @return TranslatorContract
+     * @throws InvalidConfigurationException
      */
     protected static function createTranslator(Application $app): TranslatorContract
     {

--- a/src/Core/Binders/Translator.php
+++ b/src/Core/Binders/Translator.php
@@ -18,14 +18,15 @@ use function is_string;
 class Translator implements BinderContract
 {
     /**
+     * Create the Translator instance to bind to the contract.
+     *
      * @param Application $app
-     * @throws InvalidConfigurationException if the language is misconfigured.
-     * @throws ServiceAlreadyBoundException if a translator is already bound.
+     * @return TranslatorContract
      */
-    public function bindServices(Application $app): void
+    protected static function createTranslator(Application $app): TranslatorContract
     {
         $translator = new BeadTranslator();
-        $translator->addSearchPath("i18n");
+        $translator->addSearchPath("{$app->rootDir()}/i18n");
         $language = $app->config("app.language", "en-GB");
 
         if (!is_string($language)) {
@@ -33,6 +34,16 @@ class Translator implements BinderContract
         }
 
         $translator->setLanguage($language);
-        $app->bindService(TranslatorContract::class, $translator);
+        return $translator;
+    }
+
+    /**
+     * @param Application $app
+     * @throws InvalidConfigurationException if the language is misconfigured.
+     * @throws ServiceAlreadyBoundException if a translator is already bound.
+     */
+    public function bindServices(Application $app): void
+    {
+        $app->bindService(TranslatorContract::class, static::createTranslator($app));
     }
 }

--- a/test/Core/Binders/DatabaseTest.php
+++ b/test/Core/Binders/DatabaseTest.php
@@ -11,6 +11,7 @@ use BeadTests\Framework\TestCase;
 use Mockery;
 use Mockery\MockInterface;
 
+use PDOException;
 use function array_keys;
 
 /** Test the bundled database binder. */
@@ -546,6 +547,15 @@ final class DatabaseTest extends TestCase
             ],
             "sqlsrv:Database=the_bead_db;Server=db.bead.com;ConnectionPooling=0"
         ];
+
+        yield "timeout" => [
+            [
+                "host" => "db.bead.com",
+                "name" => "the_bead_db",
+                "timeout" => "30",
+            ],
+            "sqlsrv:Database=the_bead_db;Server=db.bead.com;LoginTimeout=30"
+        ];
     }
 
     /**
@@ -610,6 +620,14 @@ final class DatabaseTest extends TestCase
             "host" => "localhost",
             "name" => "bead-unrecognised-db",
         ]);
+    }
+
+    /** Ensure connection() attempts to create a database connection. */
+    public function testConnection(): void
+    {
+        self::expectException(PDOException::class);
+        $database = new StaticXRay(DatabaseBinder::class);
+        $database->connection("", "", "");
     }
 
     public static function dataForTestBindServices1(): iterable

--- a/test/Core/Binders/DatabaseTest.php
+++ b/test/Core/Binders/DatabaseTest.php
@@ -10,8 +10,8 @@ use Bead\Testing\StaticXRay;
 use BeadTests\Framework\TestCase;
 use Mockery;
 use Mockery\MockInterface;
-
 use PDOException;
+
 use function array_keys;
 
 /** Test the bundled database binder. */

--- a/test/Core/Binders/TranslatorTest.php
+++ b/test/Core/Binders/TranslatorTest.php
@@ -22,6 +22,7 @@ final class TranslatorTest extends TestCase
     {
         $this->translator = new TranslatorBinder();
         $this->app = Mockery::mock(Application::class);
+        $this->app->shouldReceive("rootDir")->andReturn("/")->byDefault();
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Binders provided by the framework now have protected methods that act as factories to create the bound instance. This makes it easier to customise the behaviour of a specific binder without having to provide a complete implementation - a binder in an app can now inherit the framework binder, reimplement the factory, call the parent factory and tweak the returned instance before it is bound into the service container.