### PR TITLE
BEAD-172 Add generic-language fallback for regional-language translations.

### DIFF
--- a/src/Core/Binders/Translator.php
+++ b/src/Core/Binders/Translator.php
@@ -11,6 +11,7 @@ use Bead\Core\Translator as BeadTranslator;
 use Bead\Exceptions\InvalidConfigurationException;
 use Bead\Exceptions\ServiceAlreadyBoundException;
 
+use InvalidArgumentException;
 use function gettype;
 use function is_string;
 
@@ -26,15 +27,19 @@ class Translator implements BinderContract
      */
     protected static function createTranslator(Application $app): TranslatorContract
     {
-        $translator = new BeadTranslator();
-        $translator->addSearchPath("{$app->rootDir()}/i18n");
         $language = $app->config("app.language", "en-GB");
 
         if (!is_string($language)) {
             throw new InvalidConfigurationException("app.language", "Expected valid language, found " . gettype($language));
         }
 
-        $translator->setLanguage($language);
+        try {
+            $translator = new BeadTranslator($language);
+        } catch (InvalidArgumentException $err) {
+            throw new InvalidConfigurationException("app.language", $err->getMessage(), previous: $err);
+        }
+
+        $translator->addSearchPath("{$app->rootDir()}/i18n");
         return $translator;
     }
 

--- a/src/Core/Binders/Translator.php
+++ b/src/Core/Binders/Translator.php
@@ -10,8 +10,8 @@ use Bead\Core\Application;
 use Bead\Core\Translator as BeadTranslator;
 use Bead\Exceptions\InvalidConfigurationException;
 use Bead\Exceptions\ServiceAlreadyBoundException;
-
 use InvalidArgumentException;
+
 use function gettype;
 use function is_string;
 

--- a/test/Core/TranslatorTest.php
+++ b/test/Core/TranslatorTest.php
@@ -3,8 +3,8 @@
 namespace BeadTests\Core;
 
 use Bead\Core\Translator;
-use PHPUnit\Framework\TestCase;
-use ReflectionClassConstant;
+use InvalidArgumentException;
+use BeadTests\Framework\TestCase;
 
 class TranslatorTest extends TestCase
 {
@@ -18,80 +18,167 @@ class TranslatorTest extends TestCase
     public function tearDown(): void
     {
         unset($this->m_translator);
+        parent::tearDown();
     }
 
-    public function testConstructor(): void
+    /** Ensure we get the expected default language. */
+    public function testConstructor1(): void
     {
-        $translator = new Translator();
-        $defaultLanguage = new ReflectionClassConstant(Translator::class, "DefaultLanguage");
-        self::assertEquals($defaultLanguage->getValue(), $translator->language());
+        self::assertEquals("en", $this->m_translator->language());
+    }
 
+    /** Ensure we can set a language in the constructor. */
+    public function testConstructor2(): void
+    {
         $translator = new Translator("fr");
         self::assertEquals("fr", $translator->language());
     }
 
-    public function testLanguage(): void
+    /** Ensure we get back the expected language. */
+    public function testLanguage1(): void
     {
-        // ensure we can set a language
-        $this->m_translator->setLanguage("en");
-        self::assertEquals("en", $this->m_translator->language());
-
-        // ensure we can change language
         $this->m_translator->setLanguage("fr");
         self::assertEquals("fr", $this->m_translator->language());
     }
 
-    public function testHasTranslation(): void
+    /** Ensure we get back the expected language for a compound language tag. */
+    public function testLanguage2(): void
     {
-        // ensure when there's no translations file we get false back
-        $this->m_translator->setLanguage("this-language-does-not-exist");
+        $this->m_translator->setLanguage("fr-BE");
+        self::assertEquals("fr-BE", $this->m_translator->language());
+    }
+
+    /** Ensure we get back the expected generic language. */
+    public function testGenericLanguage1(): void
+    {
+        $this->m_translator->setLanguage("fr");
+        self::assertEquals("fr", $this->m_translator->genericLanguage());
+    }
+
+    /** Ensure we get back the expected generic language for a compound language tag. */
+    public function testGenericLanguage2(): void
+    {
+        $this->m_translator->setLanguage("fr-BE");
+        self::assertEquals("fr", $this->m_translator->genericLanguage());
+    }
+
+    public static function dataForTestSetLanguage1(): iterable
+    {
+        yield "leading whitespace language only" => ["  en"];
+        yield "trailing whitespace language only" => ["fr  "];
+        yield "leading and trailing whitespace language only" => ["  de  "];
+        yield "leading whitespace compound" => ["  en-GB"];
+        yield "trailing whitespace compound" => ["fr-BE  "];
+        yield "leading and trailing whitespace compound" => ["  de-AT  "];
+    }
+
+    /**
+     * Ensure whitespace is trimmed when setting the language.
+     *
+     * @dataProvider dataForTestSetLanguage1
+     */
+    public function testSetLanguage1(): void
+    {
+        $this->m_translator->setLanguage("fr-BE");
+        self::assertEquals("fr", $this->m_translator->genericLanguage());
+    }
+
+    public static function dataForTestSetLanguage2(): iterable
+    {
+        yield "empty" => [""];
+        yield "just whitespace" => ["  "];
+        yield "whitespace before region" => ["en- gb"];
+        yield "whitespace after language" => ["en -gb"];
+        yield "whitespace after language and before region" => ["en - gb"];
+        yield "excess language characters, language only" => ["enab"];
+        yield "insufficient language characters, language only" => ["e"];
+        yield "invalid language characters, language only" => ["3n"];
+        yield "excess language characters, compound" => ["enab-GB"];
+        yield "insufficient language characters, compound" => ["e-GB"];
+        yield "invalid language characters, compound" => ["3n-GB"];
+        yield "excess region characters" => ["en-GBB"];
+        yield "insufficient region characters" => ["en-G"];
+        yield "invalid region characters" => ["en-G3"];
+    }
+
+    /**
+     * Ensure we get the expected exception with a malformed language tag.
+     *
+     * @dataProvider dataForTestSetLanguage2
+     */
+    public function testSetLanguage2(string $language): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage("Expected valid IETF language tag, found \"{$language}\"");
+        $this->m_translator->setLanguage($language);
+    }
+
+    /** Ensure missing translation file indicates there is no translation. */
+    public function testHasTranslation1(): void
+    {
+        $this->m_translator->setLanguage("en-GB");
         $actual = $this->m_translator->hasTranslation("nonsense");
         self::assertFalse($actual);
+    }
 
-        // ensure when there's a translations available we get true
+    /** Ensure a translation file with a translation indicates there is a translation available. */
+    public function testHasTranslation2(): void
+    {
         $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
         $this->m_translator->setLanguage("fr");
         $actual = $this->m_translator->hasTranslation("door");
         self::assertTrue($actual);
+    }
 
-        // ensure when there's a file loaded we get false back when there's no translation available
+    /** Ensure a translation file without a matching translation indicates there is no translation available. */
+    public function testHasTranslation3(): void
+    {
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr");
         $actual = $this->m_translator->hasTranslation("window");
         self::assertFalse($actual);
     }
 
-    public function testSetLanguage(): void
+    /** Ensure we get true when the translation file doesn't have a translation but the generic-language one does. */
+    public function testHasTranslation4(): void
     {
-        self::assertNotEquals("fr", $this->m_translator->language());
-        $this->m_translator->setLanguage("fr");
-        self::assertEquals("fr", $this->m_translator->language());
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr-FR");
+        $actual = $this->m_translator->hasTranslation("door");
+        self::assertTrue($actual);
     }
 
-    public function testAddSearchPath(): void
+    /** Ensure we can add a search path. */
+    public function testAddSearchPath1(): void
     {
         $searchPath = realpath(__DIR__ . "/files/translations/");
         $this->m_translator->addSearchPath($searchPath);
         self::assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
     }
 
-    public function testTranslate(): void
+    /** Ensure search paths get canonicalised. */
+    public function testAddSearchPath2(): void
     {
-        // ensure when there's no translations file we get the original string back
-        $this->m_translator->setLanguage("this-language-does-not-exist");
-        $actual = $this->m_translator->translate("nonsense");
-        self::assertEquals("nonsense", $actual);
-
-        // ensure when there's a translations available we get it
-        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
-        $this->m_translator->setLanguage("fr");
-        $actual = $this->m_translator->translate("door");
-        self::assertEquals("porte", $actual);
-
-        // ensure when there's a file loaded we get the original string back when there's no translation available
-        $actual = $this->m_translator->translate("window");
-        self::assertEquals("window", $actual);
+        $searchPath = realpath(__DIR__ . "/files/../files/translations/");
+        $this->m_translator->addSearchPath(__DIR__ . "/files/../files/translations/");
+        self::assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
     }
 
-    public function testRemoveSearchPath(): void
+    /** Ensure duplicate search paths do not get added. */
+    public function testAddSearchPath3(): void
+    {
+        $paths = $this->m_translator->searchPaths();
+        $searchPath = realpath(__DIR__ . "/files/../files/translations/");
+        self::assertFalse(in_array($searchPath, $paths));
+        $this->m_translator->addSearchPath(__DIR__ . "/files/../files/translations/");
+        $paths = $this->m_translator->searchPaths();
+        self::assertTrue(in_array($searchPath, $paths));
+        $this->m_translator->addSearchPath($searchPath);
+        self::assertEquals($paths, $this->m_translator->searchPaths());
+    }
+
+    /** Ensure search paths can be removed. */
+    public function testRemoveSearchPath1(): void
     {
         $searchPath = realpath(__DIR__ . "/files/translations/");
         $this->m_translator->addSearchPath($searchPath);
@@ -100,7 +187,33 @@ class TranslatorTest extends TestCase
         self::assertFalse(in_array($searchPath, $this->m_translator->searchPaths()));
     }
 
-    public function testClearSearchPaths(): void
+    /** Ensure search paths are canonicalised before being removed. */
+    public function testRemoveSearchPath2(): void
+    {
+        $searchPath = realpath(__DIR__ . "/files/translations/");
+        $this->m_translator->addSearchPath($searchPath);
+        self::assertTrue(in_array($searchPath, $this->m_translator->searchPaths()));
+        $this->m_translator->removeSearchPath(__DIR__ . "/files/../files/translations/");
+        self::assertFalse(in_array($searchPath, $this->m_translator->searchPaths()));
+    }
+
+    /** Ensure removing a search path that's not a valid path does not filter the paths. */
+    public function testRemoveSearchPath3(): void
+    {
+        $path = "/this/path/does/not/exist";
+        self::assertFalse(file_exists($path));
+        $arrayFilterCalled = false;
+
+        $this->mockFunction("array_filter", function () use (&$arrayFilterCalled) {
+            $arrayFilterCalled = true;
+        });
+
+        $this->m_translator->removeSearchPath($path);
+        self::assertFalse($arrayFilterCalled);
+    }
+
+    /** Ensure clearing the search paths wipes them all out. */
+    public function testClearSearchPaths1(): void
     {
         $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
         self::assertNotEmpty($this->m_translator->searchPaths());
@@ -108,17 +221,47 @@ class TranslatorTest extends TestCase
         self::assertEmpty($this->m_translator->searchPaths());
     }
 
-    public function testSearchPaths(): void
+    /** Ensure when there's no translations file we get the original string back */
+    public function testTranslate1(): void
     {
-        $searchPaths = [
-            realpath(__DIR__ . "/files/translations/"),
-            realpath(__DIR__ . "/files/"),
-        ];
+        $this->m_translator->setLanguage("de-AT");
+        $actual = $this->m_translator->translate("nonsense");
+        self::assertEquals("nonsense", $actual);
+    }
 
-        foreach ($searchPaths as $searchPath) {
-            $this->m_translator->addSearchPath($searchPath);
-        }
+    /** ensure when there's a translation available we get it */
+    public function testTranslate2(): void
+    {
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr");
+        $actual = $this->m_translator->translate("door");
+        self::assertEquals("porte", $actual);
+    }
 
-        self::assertEquals($searchPaths, $this->m_translator->searchPaths());
+    /** ensure when there's a file loaded we get the original string back when there's no translation available */
+    public function testTranslate3(): void
+    {
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr");
+        $actual = $this->m_translator->translate("window");
+        self::assertEquals("window", $actual);
+    }
+
+    /** Ensure we fall back to the generic language if there's no region-specific translation */
+    public function testTranslate4(): void
+    {
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr-FR");
+        $actual = $this->m_translator->translate("door");
+        self::assertEquals("porte", $actual);
+    }
+
+    /** Ensure we prefer region-specific translations if both the region-specific and generic language files have a translation */
+    public function testTranslate5(): void
+    {
+        $this->m_translator->addSearchPath(__DIR__ . "/files/translations/");
+        $this->m_translator->setLanguage("fr-FR");
+        $actual = $this->m_translator->translate("fork");
+        self::assertEquals("forchette", $actual);
     }
 }

--- a/test/Core/files/translations/fr-fr.csv
+++ b/test/Core/files/translations/fr-fr.csv
@@ -1,0 +1,2 @@
+,,window,fenêtre
+,,fork,forchette

--- a/test/Core/files/translations/fr.csv
+++ b/test/Core/files/translations/fr.csv
@@ -1,1 +1,2 @@
 ,,door,porte
+,,fork,french fork


### PR DESCRIPTION
Default translator now requires IETF-like language tags. Translations will now be sourced from a language-generic translation file (e.g. "fr.csv") if the region-specific file (e.g. "fr-be.csv") does not exist or does not contain a translation for the requested string. Translation file names are all lower-case for consistency and ease of maintenance. Expanded unit test to cover more scenarios.