### PR TITLE
BEAD-169 Update default error handler logic.

### DIFF
--- a/src/Exceptions/CsrfTokenVerificationException.php
+++ b/src/Exceptions/CsrfTokenVerificationException.php
@@ -9,10 +9,8 @@ use Throwable;
 /**
  * Exception thrown when a request fails CSRF validation.
  */
-class CsrfTokenVerificationException extends Exception
+class CsrfTokenVerificationException extends HttpException
 {
-    private Request $m_request;
-
     /**
      * Initialise a new instance of the exception.
      *
@@ -23,17 +21,16 @@ class CsrfTokenVerificationException extends Exception
      */
     public function __construct(Request $request, string $message = "", int $code = 0, Throwable $previous = null)
     {
-        parent::__construct($message, $code, $previous);
-        $this->m_request = $request;
+        parent::__construct($request, $message, $code, $previous);
     }
 
     /**
-     * Fetch the request that failed CSRF validation.
+     * The HTTP status code.
      *
-     * @return Request The request.
+     * @return int 400 (Bad request).
      */
-    public function getRequest(): Request
+    public function statusCode(): int
     {
-        return $this->m_request;
+        return 400;
     }
 }

--- a/test/Core/ErrorHandlerTest.php
+++ b/test/Core/ErrorHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace BeadTests\Core;
+
+use Bead\Contracts\Logger;
+use Bead\Core\Application;
+use Bead\Core\ErrorHandler;
+use Bead\Testing\XRay;
+use BeadTests\Framework\TestCase;
+use Error;
+use Exception;
+use InvalidArgumentException;
+use Mockery;
+use Mockery\MockInterface;
+
+class ErrorHandlerTest extends TestCase
+{
+    private ErrorHandler $handler;
+
+    public function setUp(): void
+    {
+        $this->handler = new ErrorHandler();
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        unset($this->handler);
+        parent::tearDown();
+    }
+
+    /** @return MockInterface&Application */
+    private function mockApplication(): Application
+    {
+        $mock = Mockery::mock(Application::class);
+        $this->mockMethod(Application::class, "instance", $mock);
+        return $mock;
+    }
+
+    /** Ensure shouldDisplay() returns true when the app is in debug mode. */
+    public function testShouldDisplay1(): void
+    {
+        $app = $this->mockApplication();
+        $app->shouldReceive("isInDebugMode")->andReturn(true);
+        $handler = new XRay($this->handler);
+        self::assertTrue($handler->shouldDisplay(new InvalidArgumentException()));
+    }
+
+    /** Ensure shouldDisplay() returns false when the app is not in debug mode. */
+    public function testShouldDisplay2(): void
+    {
+        $app = $this->mockApplication();
+        $app->shouldReceive("isInDebugMode")->andReturn(false);
+        $handler = new XRay($this->handler);
+        self::assertFalse($handler->shouldDisplay(new InvalidArgumentException()));
+    }
+
+    /** Ensure shouldDisplay() returns false when there is no app. */
+    public function testShouldDisplay3(): void
+    {
+        $handler = new XRay($this->handler);
+        self::assertFalse($handler->shouldDisplay(new InvalidArgumentException()));
+    }
+
+    /** Ensure we get the expected view name. */
+    public function testExceptionDisplayViewName1(): void
+    {
+        $handler = new XRay($this->handler);
+        self::assertEquals("errors.exception", $handler->exceptionDisplayViewName());
+    }
+
+    /** Ensure we get the expected view name. */
+    public function testErrorPageViewName1(): void
+    {
+        $handler = new XRay($this->handler);
+        self::assertEquals("errors.error", $handler->errorPageViewName());
+    }
+
+    /** Ensure report() logs the expected message. */
+    public function testReport1(): void
+    {
+        // it's quite a pitfall to set test expectations based on this line number not changing, so we don't actually
+        // assert to verify the exception line, just to validate it
+        $error = new InvalidArgumentException("Mock exception.");
+
+        $log = Mockery::mock(Logger::class);
+
+        $log->shouldReceive("critical")
+            ->once()
+            ->with("Exception in %1[%2]: Mock exception.", Mockery::on(function (mixed $args): bool {
+                TestCase::assertIsArray($args);
+                TestCase::assertIsString($args[0]);
+                TestCase::assertEquals(__FILE__, $args[0]);
+                TestCase::assertIsInt($args[1]);
+                TestCase::assertGreaterThanOrEqual(0, $args[1]);
+                return true;
+            }));
+
+        $app = $this->mockApplication();
+        $app->shouldReceive("get")
+            ->with(Logger::class)
+            ->andReturn($log);
+
+        $handler = new XRay($this->handler);
+        $handler->report($error);
+        self::markTestAsExternallyVerified();
+    }
+
+    /** Ensure errors get converted to the expected exceptions. */
+    public function testHandleError1(): void
+    {
+        self::expectException(Error::class);
+        self::expectExceptionMessage("PHP error /a/mock/file.php@42: Mock error");
+        $this->handler->handleError(E_ERROR, "Mock error", "/a/mock/file.php", 42);
+    }
+}

--- a/test/smoke/public/css/exception.css
+++ b/test/smoke/public/css/exception.css
@@ -1,0 +1,11 @@
+ul.stack {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    margin-left: 20px;
+    font-size: 14px;
+}
+
+ul.stack li {
+    margin-top: 5px;
+}

--- a/test/smoke/routes/csrf.php
+++ b/test/smoke/routes/csrf.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use Bead\Contracts\Router;
 use Bead\Core\WebApplication;
+use Bead\Exceptions\CsrfTokenVerificationException;
 use Bead\Request;
 use Bead\View;
 
@@ -19,4 +22,8 @@ $router->registerPost("/csrf", function(Request $request): View {
 $router->registerGet("/csrf/regenerate", function (): View {
 	WebApplication::instance()->regenerateCsrf();
 	return new View("csrf");
+});
+
+$router->registerGet("/csrf/fail", function(Request $request): void {
+    throw new CsrfTokenVerificationException($request);
 });

--- a/test/smoke/views/errors/exception.php
+++ b/test/smoke/views/errors/exception.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var WebApplication $app
+ * @var array $data
+ * @var Throwable $error
+ */
+
+use Bead\Core\WebApplication;
+use Bead\View;
+
+?>
+
+<?php View::layout("layouts.layout"); ?>
+
+<?php View::push("styles"); ?>
+<link rel="stylesheet" type="text/css" href="/css/exception.css" />
+<?php View::endPush(); ?>
+
+<?php View::section("main"); ?>
+
+<!-- your HTML goes here -->
+<h1>Exception</h1>
+
+<h2><?= html($error::class) ?> <?= 0 !== $error->getCode() ? " [{$error->getCode()}]" : "" ?></h2>
+<p><?= html($error->getMessage()) ?></p>
+<h3>Location</h3>
+<div>
+    <p><strong><?= html(substr($error->getFile(), strlen(realpath($app->rootDir() . "/../..")))) ?></strong>:<?= $error->getLine() ?></p>
+</div>
+
+<h3>Stack</h3>
+<ul class="stack">
+<?php foreach ($error->getTrace() as $frame): ?>
+    <?php // in a real app you'd just use $app->rootDir() to trim the path ?>
+    <li>
+        <strong><?= html(substr($frame["file"], strlen(realpath($app->rootDir() . "/../..")))) ?></strong>:<?= $frame["line"] ?> called
+        <?=
+            html(match($frame["type"] ?? "") {
+                "::" => "{$frame["class"]}::{$frame["function"]}",
+                "->" => "{$frame["class"]}->{$frame["function"]}",
+                default => $frame["function"],
+            })
+        ?>()
+    </li>
+<?php endforeach ?>
+</ul>
+
+<?php View::endSection() ?>

--- a/test/smoke/views/includes/navbar.php
+++ b/test/smoke/views/includes/navbar.php
@@ -6,5 +6,6 @@
 <div class="separator"></div>
 <div><a href="/csrf">CSRF test</a></div>
 <div><a href="/csrf/regenerate">Regenerate CSRF</a></div>
+<div><a href="/csrf/fail">Fail CSRF Verification</a></div>
 <div class="separator"></div>
 <div><a href="/uri-signer">UriSigner test</a></div>


### PR DESCRIPTION
- will now attempt to display the exception page (in debug mode) or the generic error page (in live envs) when an exception is handled
- made `CsrfTokenVerificationException` an `HttpException`
- added CSRF fail simulation to smoke test app
- added basic exception display page to smoke test app