### PR TITLE
BEAD-175 Use assertions in Facades

### DIFF
--- a/src/Facades/Application.php
+++ b/src/Facades/Application.php
@@ -2,12 +2,11 @@
 
 namespace Bead\Facades;
 
-use BadMethodCallException;
 use Bead\Contracts\ErrorHandler as ErrorHandlerContract;
 use Bead\Contracts\Translator as TranslatorContract;
 use Bead\Core\Application as CoreApplication;
 use Bead\Database\Connection;
-use RuntimeException;
+use LogicException;
 
 /**
  * @mixin CoreApplication
@@ -47,8 +46,7 @@ class Application
     public static function __callStatic(string $method, array $args)
     {
         $app = CoreApplication::instance();
-        assert($app instanceof CoreApplication, new RuntimeException("There is no Application instance."));
-        assert(method_exists($app, $method), new BadMethodCallException("The method '{$method}' does not exist in the Application class."));
+        assert($app instanceof CoreApplication, new LogicException("There is no Application instance."));
         return [$app, $method,](...$args);
     }
 }

--- a/src/Facades/Session.php
+++ b/src/Facades/Session.php
@@ -11,11 +11,13 @@ use Bead\Exceptions\Session\SessionNotFoundException;
 use Bead\Session\PrefixedAccessor;
 use Bead\Session\Session as BeadSession;
 use Bead\Contracts\SessionHandler;
-use Exception;
 use LogicException;
 
 /**
  * Facade for easy access to the current session.
+ *
+ * @mixin BeadSession
+ * @psalm-seal-methods
  *
  * @method static int sessionIdleTimeoutPeriod()
  * @method static int sessionIdRegenerationPeriod()
@@ -92,19 +94,11 @@ final class Session
      * @param array $args The method arguments.
      *
      * @return mixed
-     * @throws Exception if the session has not been started.
      * @throws BadMethodCallException if the method does not exist in the Session class.
      */
     public static function __callStatic(string $method, array $args)
     {
-        if (!isset(self::$session)) {
-            throw new Exception("Session not started.");
-        }
-
-        if (!method_exists(self::$session, $method)) {
-            throw new BadMethodCallException("The method '{$method}' does not exist in the Session class.");
-        }
-
+        assert(null !== self::$session, new LogicException("Session not started."));
         return [self::$session, $method](...$args);
     }
 }

--- a/src/Facades/WebApplication.php
+++ b/src/Facades/WebApplication.php
@@ -8,7 +8,7 @@ use Bead\Contracts\Router as RouterContract;
 use Bead\Core\Plugin;
 use Bead\Web\Application as BeadWebApplication;
 use Bead\Web\Request;
-use RuntimeException;
+use LogicException;
 
 use function assert;
 use function method_exists;
@@ -43,8 +43,7 @@ class WebApplication extends Application
     public static function __callStatic(string $method, array $args)
     {
         $app = BeadWebApplication::instance();
-        assert($app instanceof BeadWebApplication, new RuntimeException("There is no Application instance."));
-        assert(method_exists($app, $method), new BadMethodCallException("The method '{$method}' does not exist in the Application class."));
+        assert($app instanceof BeadWebApplication, new LogicException("There is no Application instance."));
         return [$app, $method,](...$args);
     }
 }


### PR DESCRIPTION
 Use assertions in Facades where errors indicate programmer errors to simplify the exception landscape.