### PR TITLE
BEAD-174 check exception constructors

### DIFF
--- a/src/Exceptions/Http/CsrfTokenVerificationException.php
+++ b/src/Exceptions/Http/CsrfTokenVerificationException.php
@@ -2,9 +2,6 @@
 
 namespace Bead\Exceptions\Http;
 
-use Bead\Web\Request;
-use Throwable;
-
 /** Exception thrown when a request fails CSRF verification. */
 class CsrfTokenVerificationException extends HttpException
 {

--- a/src/Exceptions/Http/CsrfTokenVerificationException.php
+++ b/src/Exceptions/Http/CsrfTokenVerificationException.php
@@ -5,24 +5,9 @@ namespace Bead\Exceptions\Http;
 use Bead\Web\Request;
 use Throwable;
 
-/**
- * Exception thrown when a request fails CSRF validation.
- */
+/** Exception thrown when a request fails CSRF verification. */
 class CsrfTokenVerificationException extends HttpException
 {
-    /**
-     * Initialise a new instance of the exception.
-     *
-     * @param Request $request The request that failed CSRF validation.
-     * @param string $message The optional error message. Defaults to an empty string.
-     * @param int $code The optional error code. Defaults to 0.
-     * @param Throwable|null $previous The optional Throwable that was previously thrown. Defaults to null.
-     */
-    public function __construct(Request $request, string $message = "", int $code = 0, Throwable $previous = null)
-    {
-        parent::__construct($request, $message, $code, $previous);
-    }
-
     /**
      * The HTTP status code.
      *


### PR DESCRIPTION
CsrfTokenVerificationException had a redundant constructor. This PR removes it, and removes the imports that are no longer required.