### PR TITLE
BEAD-182 recursively follow config keys using dot syntax

### DIFF
--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -219,12 +219,22 @@ abstract class Application implements ServiceContainer, ContainerInterface
             return $this->m_config;
         }
 
-        if (str_contains($key, ".")) {
-            [$file, $key] = explode(".", $key, 2);
-            return $this->m_config[$file][$key] ?? $default;
+        $config = $this->m_config;
+
+        while (str_contains($key, ".")) {
+            [$configKey, $key] = explode(".", $key, 2);
+            $config = $config[$configKey] ?? null;
+
+            if (!is_array($config)) {
+                return $default;
+            }
+
+            if (array_key_exists($key, $config)) {
+                return $config[$key];
+            }
         }
 
-        return $this->m_config[$key] ?? $default;
+        return $config[$key] ?? $default;
     }
 
     /** Fetch the application's title.

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -5,9 +5,45 @@ namespace BeadTests\Core;
 use Bead\Core\Application;
 use Bead\Exceptions\ServiceAlreadyBoundException;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+use function is_array;
 
 class ApplicationTest extends TestCase
 {
+    private const TestConfig = [
+        "mail" => [
+            "transport" => "mailgun",
+            "transports" => [
+                "php" => [
+                    "driver" => "php",
+                ],
+
+                "mailgun" => [
+                    "driver" => "mailgun",
+                    "endpoint" => "https://api.eu.mailgun.net",
+                    "key" => "some key",
+                ],
+
+                "fake" => [
+                    "driver" => "fake",
+                    "values" => [
+                        "embedded" => true,
+                        "descend" => [
+                            "key" => "value",
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        "dotted" => [
+            "with" => [
+                "dot" => "not this",
+            ],
+            "with.dot" => "but this",
+        ],
+    ];
+
     private Application $m_app;
 
     public function setUp(): void
@@ -89,5 +125,42 @@ class ApplicationTest extends TestCase
         $this->m_app->bindService("foo", $original);
         self::assertTrue($this->m_app->has("foo"));
         self::assertFalse($this->m_app->has("fox"));
+    }
+
+    public static function dataForTestConfig1(): iterable
+    {
+        yield "whole-file-config" => ["mail", null, self::TestConfig["mail"],];
+        yield "non-existent-file" => ["foo", null, null,];
+        yield "non-existent-file-default" => ["foo", "bar", "bar",];
+        yield "top-level-from-file" => ["mail.transport", null, "mailgun",];
+        yield "nested-in-file" => ["mail.transports.mailgun.key", null, "some key",];
+        yield "nested-doesn't-exist" => ["mail.transports.fake.key", null, null,];
+        yield "nested-doesn't-exist-default" => ["mail.transports.fake.key", "foo", "foo",];
+        yield "nested-array" => ["mail.transports.fake.values", null, self::TestConfig["mail"]["transports"]["fake"]["values"],];
+        yield "prefers-actual-key-to-array-descent" => ["dotted.with.dot", null, "but this",];
+    }
+
+    /**
+     * Ensure the config is traversed correctly.
+     *
+     * @dataProvider dataForTestConfig1
+     */
+    public function testConfig1(string $key, mixed $default, mixed $expected): void
+    {
+        $config = new ReflectionProperty(Application::class, "m_config");
+        $config->setAccessible(true);
+        $config->setValue($this->m_app, self::TestConfig);
+
+        if (null === $default) {
+            $actual = $this->m_app->config($key);
+        } else {
+            $actual = $this->m_app->config($key, $default);
+        }
+
+        if (is_array($expected)) {
+            self::assertEqualsCanonicalizing($expected, $actual);
+        } else {
+            self::assertEquals($expected, $actual);
+        }
     }
 }


### PR DESCRIPTION
At present you can get the config from a file as an array, but you have to index into that array yourself. This PR enables the use of dot.syntax to descend into arrays directly without having to store the array and index manually.

In cases where a dot.syntax key exists, that key is preferred over descending further into the config. For example,

```php
"config" => [
    "key" => [
        "value" => "not this",
    ],
    "key.value" => "this",
],

$value = Application::instance()->config("config.key.value");
// $value = "this";
```