### PR TITLE
BEAD-158 Add Buffer stream class

### DIFF
--- a/src/Streams/Buffer.php
+++ b/src/Streams/Buffer.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Streams;
+
+use InvalidArgumentException;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+/**
+ * An implementation of the PSR-7 StreamInterface backed by a fixed string buffer.
+ */
+class Buffer implements StreamInterface
+{
+    /** @var string The buffer backing the stream. */
+    private string $buffer;
+
+    /**
+     * This is null when the stream has been manually closed.
+     *
+     * @var int|null The current position in the buffer or `null` if there's no buffer or the stream has been closed.
+     */
+    private ?int $pos;
+
+    /**
+     * Initialise a new StringStream.
+     *
+     * @param string $buffer The string buffer with which to back the stream.
+     */
+    public function __construct(string $buffer)
+    {
+        $this->buffer = $buffer;
+        $this->pos = 0;
+    }
+
+    /**
+     * Cast the stream to a string.
+     *
+     * Provides the full content of the buffer if the stream is open, or an empty string if it's closed. The buffer is
+     * seeked to the end on exit (i.e. eof() === true).
+     *
+     * @return string The full buffer, or an empty string if the stream is closed.
+     */
+    public function __toString()
+    {
+        if ($this->isOpen()) {
+            $this->pos = $this->getSize();
+            return $this->buffer;
+        }
+
+        return "";
+    }
+
+    /**
+     * Close the stream.
+     */
+    public function close()
+    {
+        $this->pos = null;
+    }
+
+    /**
+     * Detach the stream.
+     *
+     * StringStream objects cannot be detached.
+     *
+     * @return null
+     */
+    public function detach()
+    {
+        return null;
+    }
+
+    /** Determine whether the stream is open. */
+    public function isOpen(): bool
+    {
+        return null !== $this->pos;
+    }
+
+    /**
+     * Throw if the stream is not open.
+     *
+     * @throws RuntimeException
+     */
+    private function checkOpen(): void
+    {
+        if (!$this->isOpen()) {
+            throw new RuntimeException("The Buffer is not open");
+        }
+    }
+
+    /**
+     * Determine whether the end of the stream has been reached.
+     *
+     * A stream that isn't open is not eof().
+     *
+     * @return bool `true` if it has, `false` if not.
+     */
+    public function eof(): bool
+    {
+        return $this->pos === strlen($this->buffer);
+    }
+
+    /**
+     * Determine whether the stream is seekable.
+     *
+     * @return bool `true` if the stream is open, `false` if not.
+     */
+    public function isSeekable()
+    {
+        return $this->isOpen();
+    }
+
+    /**
+     * Determine whether the stream is readable.
+     *
+     * @return bool `true` if the stream is open, `false` if not.
+     */
+    public function isReadable()
+    {
+        return $this->isOpen();
+    }
+
+    /**
+     * Determine whether the stream is writable.
+     *
+     * Buffers are never writable.
+     *
+     * @return bool `false`.
+     */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /**
+     * Fetch the size of the stream.
+     *
+     * @return int|null The size of the buffer if open, `null` if not.
+     */
+    public function getSize()
+    {
+        return $this->isOpen() ? strlen($this->buffer) : null;
+    }
+
+    /**
+     * Fetch the location of the current seek pointer.
+     *
+     * This is expressed in bytes from the beginning of the stream.
+     *
+     * @return int The position.
+     * @throws RuntimeException if the stream is not open.
+     */
+    public function tell(): int
+    {
+        $this->checkOpen();
+        return $this->pos;
+    }
+
+    /**
+     * @param int $offset How far to seek in bytes.
+     * @param int $whence Where to seek from. Must be either `SEEK_SET`, `SEEK_CUR` or `SEEK_END`. Defaults to SEEK_SET.
+     *
+     * @throws RuntimeException if the stream is not open.
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        assert(is_int($offset), new RuntimeException("Expecting int offset for Argument #1 \$offset of seek(), found " . gettype($offset)));
+        assert(is_int($whence), new RuntimeException("Expecting SEEK_SET, SEEK_CUR or SEEK_END for Argument #2 \$whence of seek(), found " . gettype($whence)));
+        $this->checkOpen();
+
+        switch ($whence) {
+            case SEEK_SET:
+                break;
+
+            case SEEK_CUR:
+                $offset += $this->pos;
+                break;
+
+            case SEEK_END:
+                $offset += $this->getSize();
+                break;
+
+            default:
+                throw new RuntimeException("Expecting SEEK_SET, SEEK_CUR or SEEK_END for Argument #2 \$whence of seek(), found {$whence}");
+        }
+
+        if (0 > $offset || $offset > $this->getSize()) {
+            throw new RuntimeException("Requested seek is beyond the bounds of the buffer");
+        }
+
+        $this->pos = $offset;
+    }
+
+    /**
+     * Seek to the beginning of the stream.
+     *
+     * @throws RuntimeException if the stream is not open.
+     */
+    public function rewind()
+    {
+        $this->seek(0);
+    }
+
+    /**
+     * Read bytes from the stream.
+     *
+     * @param int $length The maximum number of bytes to read.
+     *
+     * @return Buffer
+     * @throws RuntimeException if the read length is invalid.
+     */
+    public function read($length): string
+    {
+        assert(is_int($length), new RuntimeException("Expecting int >= 0 length for Argument #1 \$length of read(), found " . gettype($length)));
+
+        if (0 > $length) {
+            throw new RuntimeException("Expecting int >= 0 length for Argument #1 \$length of read(), found {$length}");
+        }
+
+        if (!$this->isOpen()) {
+            return "";
+        }
+
+        $start = $this->pos;
+        $length = min($length, $this->getSize() - $this->pos);
+        $this->pos += $length;
+        return substr($this->buffer, $start, $length);
+    }
+
+    /**
+     * Fetch the metatdata for the stream.
+     *
+     * Buffers don't have metadata.
+     *
+     * @param string $key The optional metatdata key to fetch.
+     *
+     * @return null
+     */
+    public function getMetadata($key = null)
+    {
+        return null;
+    }
+
+    /**
+     * Write to the stream.
+     *
+     * Always throws an exception - Buffers are not writable.
+     *
+     * @param string $string The bytes to write.
+     *
+     * @throws RuntimeException
+     */
+    public function write($string)
+    {
+        throw new RuntimeException("Buffers are read-only");
+    }
+
+    /**
+     * Fetch the remaining content of the stream.
+     *
+     * @return string The content of the buffer from the current position, or an empty string if the stream is EOF.
+     * @throws RuntimeException if the buffer is closed
+     */
+    public function getContents()
+    {
+        $this->checkOpen();
+        $pos = $this->tell();
+        $this->seek(0, SEEK_END);
+        return substr($this->buffer, $pos);
+    }
+}

--- a/test/Streams/BufferTest.php
+++ b/test/Streams/BufferTest.php
@@ -1,0 +1,446 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Streams;
+
+use Bead\Streams\Buffer;
+use Bead\Testing\XRay;
+use BeadTests\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+class BufferTest extends TestCase
+{
+    private const BufferContent = "the content of the buffer";
+
+    private Buffer $buffer;
+
+    public function setUp(): void
+    {
+        $this->buffer = new Buffer(self::BufferContent);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->buffer);
+        parent::tearDown();
+    }
+
+    /** Ensure the constructor initialises the buffer as expected. */
+    public function testConstructor1(): void
+    {
+        $buffer = new Buffer("some content");
+        self::assertEquals(0, $buffer->tell());
+        self::assertEquals("some content", (string) $buffer);
+    }
+
+    /** Ensure casting returns the full buffer stream is at the beginning, and seeks to the end. */
+    public function testCastString1(): void
+    {
+        self::assertEquals(0, $this->buffer->tell());
+        self::assertEquals(self::BufferContent, (string) $this->buffer);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+    }
+
+    /** Ensure casting returns the full buffer when the seek location is beyond the beginning, and seeks to the end. */
+    public function testCastString2(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+        self::assertEquals(self::BufferContent, (string) $this->buffer);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+    }
+
+    /** Ensure casting returns the full buffer when eof(), and seeks to the end. */
+    public function testCastString3(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+        self::assertEquals(self::BufferContent, (string) $this->buffer);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+    }
+
+    /** Ensure casting returns an empty string when the buffer is closed. */
+    public function testCastString4(): void
+    {
+        $this->buffer->close();
+        self::assertEquals("", (string) $this->buffer);
+        self::assertFalse($this->buffer->isOpen());
+    }
+    
+    /** Ensure calling close() closes the buffer. */
+    public function testClose1(): void
+    {
+        self::assertTrue($this->buffer->isOpen());
+        $this->buffer->close();
+        self::assertFalse($this->buffer->isOpen());
+    }
+
+    /** Ensure detach() returns null. */
+    public function testDetach1(): void
+    {
+        self::assertNull($this->buffer->detach());
+    }
+    
+    /** Ensure isOpen() reports an open buffer as open. */
+    public function testIsOpen1(): void
+    {
+        self::assertTrue($this->buffer->isOpen());
+    }
+    
+    /** Ensure isOpen() reports a closed buffer as not open. */
+    public function testIsOpen2(): void
+    {
+        $this->buffer->close();
+        self::assertFalse($this->buffer->isOpen());
+    }
+    
+    /** Ensure checkOpen() doesn't throw when the stream is open. */
+    public function testCheckOpen1(): void
+    {
+        $threw = false;
+        
+        try {
+            (new XRay($this->buffer))->checkOpen();
+        } catch (Throwable) {
+            $threw = true;
+        }
+        
+        self::assertFalse($threw);
+    }
+    
+    /** Ensure checkOpen() throws when the stream is closed. */
+    public function testCheckOpen2(): void
+    {
+        $this->buffer->close();
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("The Buffer is not open");
+        (new XRay($this->buffer))->checkOpen();
+    }
+    
+    /** Ensure eof() is false when the buffer has not been exhausted */
+    public function testEof1(): void
+    {
+        self::assertEquals(0, $this->buffer->tell());
+        self::assertFalse($this->buffer->eof());
+    }
+    
+    /** Ensure eof() is false when the buffer has been seeked partway through */
+    public function testEof2(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+        self::assertFalse($this->buffer->eof());
+    }
+
+    /** Ensure eof() is true when the buffer has been seeked all the way through */
+    public function testEof3(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+    }
+
+    /** Ensure eof() is false when the buffer has been closed */
+    public function testEof4(): void
+    {
+        $this->buffer->close();
+        self::assertFalse($this->buffer->eof());
+    }
+    
+    /** Ensure an open buffer is seekable. */
+    public function testIsSeekable1(): void
+    {
+        self::assertTrue($this->buffer->isSeekable());
+    }
+    
+    /** Ensure an EOF buffer is seekable. */
+    public function testIsSeekable2(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertTrue($this->buffer->eof());
+        self::assertTrue($this->buffer->isSeekable());
+    }
+    
+    /** Ensure a closed buffer is not seekable. */
+    public function testIsSeekable3(): void
+    {
+        $this->buffer->close();
+        self::assertFalse($this->buffer->isSeekable());
+    }
+    
+    /** Ensure an open buffer is seadable. */
+    public function testIsReadable1(): void
+    {
+        self::assertTrue($this->buffer->isReadable());
+    }
+    
+    /** Ensure an EOF buffer is readable. */
+    public function testIsReadable2(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertTrue($this->buffer->eof());
+        self::assertTrue($this->buffer->isReadable());
+    }
+    
+    /** Ensure a closed buffer is not readable. */
+    public function testIsReadable3(): void
+    {
+        $this->buffer->close();
+        self::assertFalse($this->buffer->isReadable());
+    }
+
+    /** Ensure Buffers are not writable */
+    public function testIsWritable1(): void
+    {
+        self::assertTrue($this->buffer->isOpen());
+        self::assertFalse($this->buffer->isWritable());
+    }
+
+    /** Ensure we can get the size of an open buffer. */
+    public function testGetSize1(): void
+    {
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->getSize());
+    }
+
+    /** Ensure seeking doesn't change the size of an open buffer. */
+    public function testGetSize2(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->getSize());
+    }
+
+    /** Ensure EOF change the size of an open buffer. */
+    public function testGetSize3(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->getSize());
+    }
+
+    /** Ensure we get a null size when the buffer is closed. */
+    public function testGetSize4(): void
+    {
+        $this->buffer->close();
+        self::assertNull($this->buffer->getSize());
+    }
+
+    /** Ensure we can read the position in a buffer */
+    public function testTell1(): void
+    {
+        self::assertEquals(0, $this->buffer->tell());
+    }
+
+    /** Ensure we can read the position in a buffer after seeking. */
+    public function testTell2(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+    }
+
+    /** Ensure we can read the position in a buffer after seeking to the end. */
+    public function testTell3(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+    }
+
+    /** Ensure tell() throws when the buffer is closed. */
+    public function testTell4(): void
+    {
+        $this->buffer->close();
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("The Buffer is not open");
+        $this->buffer->tell();
+    }
+
+    /** TODO testSeek1()... */
+
+    /** Ensure we can rewind to the start of the buffer. */
+    public function testRewind1(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+        $this->buffer->rewind();
+        self::assertEquals(0, $this->buffer->tell());
+    }
+
+    /** Ensure we can rewind to the start of the buffer from EOF. */
+    public function testRewind2(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertTrue($this->buffer->eof());
+        $this->buffer->rewind();
+        self::assertEquals(0, $this->buffer->tell());
+    }
+
+    /** Ensure rewinding a closed buffer throws. */
+    public function testRewind3(): void
+    {
+        $this->buffer->close();
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("The Buffer is not open");
+        $this->buffer->rewind();
+    }
+
+    public static function dataForTestRead1(): iterable
+    {
+        yield "0 bytes from start" => [0, 0, "", 0,];
+        yield "0 bytes from end" => [strlen(self::BufferContent), 0, "", strlen(self::BufferContent),];
+        yield "0 bytes from middle" => [10, 0, "", 10,];
+        yield "10 bytes from start" => [0, 10, substr(self::BufferContent, 0, 10), 10,];
+        yield "10 bytes from end" => [strlen(self::BufferContent), 10, "", strlen(self::BufferContent),];
+        yield "10 bytes from middle" => [10, 10, substr(self::BufferContent, 10, 10), 20,];
+        yield "100 bytes from start" => [0, 100, self::BufferContent, strlen(self::BufferContent),];
+        yield "100 bytes from end" => [strlen(self::BufferContent), 100, "", strlen(self::BufferContent),];
+        yield "100 bytes from middle" => [10, 100, substr(self::BufferContent, 10), strlen(self::BufferContent),];
+
+        for ($idx = 0; $idx < strlen(self::BufferContent); ++$idx) {
+            yield "1 byte from offset {$idx}" => [$idx, 1, substr(self::BufferContent, $idx, 1), $idx + 1,];
+        }
+
+        yield "1 byte from penultimate position" => [strlen(self::BufferContent) - 1, 1, substr(self::BufferContent, -1), strlen(self::BufferContent),];
+
+        yield "10 bytes from penultimate position" => [strlen(self::BufferContent) - 1, 1, substr(self::BufferContent, -1), strlen(self::BufferContent),];
+    }
+
+    /**
+     * Ensure we read the expected content.
+     * @dataProvider dataForTestRead1
+     */
+    public function testRead1(int $seek, int $length, string $expectedRead, int $expectedTell): void
+    {
+        $this->buffer->seek($seek);
+        self::assertEquals($expectedRead, $this->buffer->read($length));
+        self::assertEquals($expectedTell, $this->buffer->tell());
+    }
+
+    public static function dataForTestRead2(): iterable
+    {
+        yield "empty string" => ["",];
+        yield "whitespace" => ["  ",];
+        yield "int string" => ["2",];
+        yield "float string" => ["3.14",];
+        yield "float" => [3.14,];
+        yield "array" => [[10],];
+        yield "true" => [true,];
+        yield "false" => [false,];
+        yield "null" => [null,];
+        yield "object" => [(object) ["int" => 10],];
+    }
+
+    /**
+     * Ensure read() throws with non-int lengths.
+     *
+     * @dataProvider dataForTestRead2
+     */
+    public function testRead2(mixed $length): void
+    {
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("Expecting int >= 0 length for Argument #1 \$length of read(), found " . gettype($length));
+        $this->buffer->read($length);
+    }
+
+    public static function dataForTestRead3(): iterable
+    {
+        yield "minus-1" => [-1];
+        yield "minus-42" => [-42];
+        yield "PHP_INT_MIN" => [PHP_INT_MIN];
+    }
+
+    /**
+     * Ensure read() throws with negative lengths.
+     *
+     * @dataProvider dataForTestRead3
+     */
+    public function testRead3(int $length): void
+    {
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("Expecting int >= 0 length for Argument #1 \$length of read(), found {$length}");
+        $this->buffer->read($length);
+    }
+
+    /** Ensure the metadata is null */
+    public function testGetMetadata1(): void
+    {
+        self::assertNull($this->buffer->getMetadata());
+    }
+
+    public static function dataForTestGetMetadata2(): iterable
+    {
+        yield "empty-string" => [""];
+        yield "whitespace" => [" "];
+
+        for ($idx = 65; $idx < 91; ++$idx) {
+            $ch = chr($idx);
+            yield $ch => [$ch];
+            $ch = strtolower($ch);
+            yield $ch => [$ch];
+        }
+
+        yield "longer-text-key" => ["a-key"];
+    }
+
+    /**
+     * Ensure the metadata is null when given a key.
+     *
+     * @dataProvider dataForTestGetMetadata2
+     */
+    public function testGetMetadata2(string $key): void
+    {
+        self::assertNull($this->buffer->getMetadata($key));
+    }
+
+    /** Ensure writing to a Buffer throws. */
+    public function testWrite1(): void
+    {
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("Buffers are read-only");
+        $this->buffer->write("bead");
+    }
+
+    /** Ensure getContents() fetches the full buffer when positioned at the start. */
+    public function testGetContents1(): void
+    {
+        self::assertEquals(0, $this->buffer->tell());
+        self::assertEquals(self::BufferContent, $this->buffer->getContents());
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+    }
+
+    /** Ensure getContents() fetches the expected part of the buffer when partially seeked. */
+    public function testGetContents2(): void
+    {
+        $this->buffer->seek(10);
+        self::assertEquals(10, $this->buffer->tell());
+        self::assertEquals(substr(self::BufferContent, 10), $this->buffer->getContents());
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+    }
+
+    /** Ensure getContents() returns an empty string when EOF. */
+    public function testGetContents3(): void
+    {
+        $this->buffer->seek(0, SEEK_END);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+        $actual = $this->buffer->getContents();
+        self::assertIsString($actual);
+        self::assertEquals("", $actual);
+        self::assertEquals(strlen(self::BufferContent), $this->buffer->tell());
+        self::assertTrue($this->buffer->eof());
+    }
+
+    /** Ensure getContents() returns null when closed. */
+    public function testGetContents4(): void
+    {
+        $this->buffer->close();
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage("The Buffer is not open");
+        $this->buffer->getContents();
+    }
+}

--- a/test/Streams/BufferTest.php
+++ b/test/Streams/BufferTest.php
@@ -69,7 +69,7 @@ class BufferTest extends TestCase
         self::assertEquals("", (string) $this->buffer);
         self::assertFalse($this->buffer->isOpen());
     }
-    
+
     /** Ensure calling close() closes the buffer. */
     public function testClose1(): void
     {
@@ -83,34 +83,34 @@ class BufferTest extends TestCase
     {
         self::assertNull($this->buffer->detach());
     }
-    
+
     /** Ensure isOpen() reports an open buffer as open. */
     public function testIsOpen1(): void
     {
         self::assertTrue($this->buffer->isOpen());
     }
-    
+
     /** Ensure isOpen() reports a closed buffer as not open. */
     public function testIsOpen2(): void
     {
         $this->buffer->close();
         self::assertFalse($this->buffer->isOpen());
     }
-    
+
     /** Ensure checkOpen() doesn't throw when the stream is open. */
     public function testCheckOpen1(): void
     {
         $threw = false;
-        
+
         try {
             (new XRay($this->buffer))->checkOpen();
         } catch (Throwable) {
             $threw = true;
         }
-        
+
         self::assertFalse($threw);
     }
-    
+
     /** Ensure checkOpen() throws when the stream is closed. */
     public function testCheckOpen2(): void
     {
@@ -119,14 +119,14 @@ class BufferTest extends TestCase
         self::expectExceptionMessage("The Buffer is not open");
         (new XRay($this->buffer))->checkOpen();
     }
-    
+
     /** Ensure eof() is false when the buffer has not been exhausted */
     public function testEof1(): void
     {
         self::assertEquals(0, $this->buffer->tell());
         self::assertFalse($this->buffer->eof());
     }
-    
+
     /** Ensure eof() is false when the buffer has been seeked partway through */
     public function testEof2(): void
     {
@@ -149,13 +149,13 @@ class BufferTest extends TestCase
         $this->buffer->close();
         self::assertFalse($this->buffer->eof());
     }
-    
+
     /** Ensure an open buffer is seekable. */
     public function testIsSeekable1(): void
     {
         self::assertTrue($this->buffer->isSeekable());
     }
-    
+
     /** Ensure an EOF buffer is seekable. */
     public function testIsSeekable2(): void
     {
@@ -163,20 +163,20 @@ class BufferTest extends TestCase
         self::assertTrue($this->buffer->eof());
         self::assertTrue($this->buffer->isSeekable());
     }
-    
+
     /** Ensure a closed buffer is not seekable. */
     public function testIsSeekable3(): void
     {
         $this->buffer->close();
         self::assertFalse($this->buffer->isSeekable());
     }
-    
+
     /** Ensure an open buffer is seadable. */
     public function testIsReadable1(): void
     {
         self::assertTrue($this->buffer->isReadable());
     }
-    
+
     /** Ensure an EOF buffer is readable. */
     public function testIsReadable2(): void
     {
@@ -184,7 +184,7 @@ class BufferTest extends TestCase
         self::assertTrue($this->buffer->eof());
         self::assertTrue($this->buffer->isReadable());
     }
-    
+
     /** Ensure a closed buffer is not readable. */
     public function testIsReadable3(): void
     {


### PR DESCRIPTION
Adds a read-only PSR7 StreamInterface implementation that uses a fixed string buffer for storage.