### PR TITLE
BEAD-179 Refactor the log service binder to support more flexible configuration.

### DIFF
--- a/src/Core/Binders/Logger.php
+++ b/src/Core/Binders/Logger.php
@@ -81,8 +81,12 @@ class Logger implements BinderContract
     /**
      * Create the Logger instance to bind to the contract in the service container.
      *
+     * @param string $loggerName
      * @param array $config
      * @return LoggerContract
+     *
+     * @throws InvalidConfigurationException If the configuration for the named logger is not found or has an
+     * unrecognised driver.
      */
     protected function createLogger(string $loggerName, array $config): LoggerContract
     {


### PR DESCRIPTION
It's now possible to configure multiple logs of different types to all receive the log messages.