### PR TITLE
BEAD-186 Support configuration of log levels.

### DIFF
--- a/src/Core/Binders/Logger.php
+++ b/src/Core/Binders/Logger.php
@@ -96,13 +96,16 @@ class Logger implements BinderContract
 
         $config = $config[$loggerName];
 
-        return match ($config["driver"] ?? null) {
+        $logger = match ($config["driver"] ?? null) {
             "file" => $this->createFileLogger($config),
             "stdout" => new StandardOutputLogger(),
             "stderr" => new StandardErrorLogger(),
             "null" => new NullLogger(),
             default => throw new InvalidConfigurationException("log.logs.{$loggerName}.driver", "Expected recognised log driver, found \"{$config["driver"]}\""),
         };
+
+        $logger->setLevel($config["level"] ?? LoggerContract::ErrorLevel);
+        return $logger;
     }
 
     /**

--- a/test/Core/Binders/LoggerTest.php
+++ b/test/Core/Binders/LoggerTest.php
@@ -158,11 +158,27 @@ final class LoggerTest extends TestCase
     }
 
     /** Ensure createLogger() throws when the named logger is not found. */
-    public function testCreateLogger(): void
+    public function testCreateLogger1(): void
     {
         self::expectException(InvalidConfigurationException::class);
         self::expectExceptionMessage("Expected configuration array for \"file\", found none");
         (new XRay($this->logger))->createLogger("file", [" file" => [],]);
+    }
+
+    /** Ensure createLogger() uses the configured log level. */
+    public function testCreateLogger2(): void
+    {
+        $logger = (new XRay($this->logger))->createLogger("null", ["null" => ["driver" => "null", "level" => LoggerContract::DebugLevel,],]);
+        self::assertInstanceOf(NullLogger::class, $logger);
+        self::assertEquals(LoggerContract::DebugLevel, $logger->level());
+    }
+
+    /** Ensure createLogger() uses the default log level when none is given. */
+    public function testCreateLogger3(): void
+    {
+        $logger = (new XRay($this->logger))->createLogger("null", ["null" => ["driver" => "null",],]);
+        self::assertInstanceOf(NullLogger::class, $logger);
+        self::assertEquals(LoggerContract::ErrorLevel, $logger->level());
     }
 
     public static function dataForTestBindServices1(): iterable


### PR DESCRIPTION
Each defined logger in an app can have its own log level configured.