### PR TITLE
BEAD-192 http reason phrase in responses

### DIFF
--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -5,6 +5,7 @@ namespace Bead\Contracts;
 interface Response
 {
     public function statusCode(): int;
+    public function reasonPhrase(): string;
     public function contentType(): string;
     public function headers(): array;
     public function content(): string;

--- a/src/Exceptions/Http/HttpException.php
+++ b/src/Exceptions/Http/HttpException.php
@@ -66,7 +66,7 @@ abstract class HttpException extends Exception implements Response
         if (isset($viewPath)) {
             try {
                 return (new View("{$viewPath}.{$this->statusCode()}", ["message" => $this->getMessage()]))->render();
-            } catch (ViewNotFoundException|ViewRenderingException) {
+            } catch (ViewNotFoundException | ViewRenderingException) {
                 // we only want to catch these - any others should be handled by some other means
             }
         }

--- a/src/Exceptions/Http/HttpException.php
+++ b/src/Exceptions/Http/HttpException.php
@@ -6,6 +6,7 @@ use Bead\Contracts\Response;
 use Bead\Exceptions\ViewNotFoundException;
 use Bead\Exceptions\ViewRenderingException;
 use Bead\Responses\DoesntHaveHeaders;
+use Bead\Responses\HasDefaultReasonPhrase;
 use Bead\Responses\NaivelySendsContent;
 use Bead\View;
 use Bead\Web\Application;
@@ -22,6 +23,7 @@ use Throwable;
  */
 abstract class HttpException extends Exception implements Response
 {
+    use HasDefaultReasonPhrase;
     use DoesntHaveHeaders;
     use NaivelySendsContent;
 

--- a/src/Exceptions/Http/HttpException.php
+++ b/src/Exceptions/Http/HttpException.php
@@ -77,6 +77,7 @@ abstract class HttpException extends Exception implements Response
             $message = "";
         }
 
+        // NOTE uses default reasonPhrase() so no need to escape for HTML as it's known to be safe
         return <<<HTML
 <!DOCTYPE html>
 <html lang="en">
@@ -84,7 +85,7 @@ abstract class HttpException extends Exception implements Response
 <title>HTTP Error {$this->statusCode()}</title>
 </head>
 <body>
-<h1>HTTP Error {$this->statusCode()} {$this->reasonPhrase()}</h1>
+<h2>HTTP Error {$this->statusCode()} <em>{$this->reasonPhrase()}</em></h2>
 {$message}
 </body>
 </html>

--- a/src/Responses/AbstractResponse.php
+++ b/src/Responses/AbstractResponse.php
@@ -12,6 +12,7 @@ use Bead\Contracts\Response;
 abstract class AbstractResponse implements Response
 {
     use CanSetStatusCode;
+    use HasDefaultReasonPhrase;
     use CanSetContentType;
     use DoesntHaveHeaders;
     use NaivelySendsContent;

--- a/src/Responses/CanSetReasonPhrase.php
+++ b/src/Responses/CanSetReasonPhrase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bead\Responses;
+
+/**
+ * Trait for responses that allow the reason phrase to be set.
+ *
+ * Use this to avoid boilerplate.
+ */
+trait CanSetReasonPhrase
+{
+    /** @var string The HTTP reason phrase. */
+    private string $m_reasonPhrase;
+
+    /**
+     * Fetch the HTTP reason phrase.
+     *
+     * @return string The reason phrase.
+     */
+    public function reaspnPhrase(): string
+    {
+        return $this->m_reasonPhrase;
+    }
+
+    /**
+     * Set the HTTP reason phrase.
+     *
+     * @param string $reasonPhrase The reason phrase.
+     */
+    public function setReasonPhrase(string $reasonPhrase): void
+    {
+        $this->m_reasonPhrase = $reasonPhrase;
+    }
+}

--- a/src/Responses/CanSetReasonPhrase.php
+++ b/src/Responses/CanSetReasonPhrase.php
@@ -17,7 +17,7 @@ trait CanSetReasonPhrase
      *
      * @return string The reason phrase.
      */
-    public function reaspnPhrase(): string
+    public function reasonPhrase(): string
     {
         return $this->m_reasonPhrase;
     }

--- a/src/Responses/HasDefaultReasonPhrase.php
+++ b/src/Responses/HasDefaultReasonPhrase.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Responses;
+
+trait HasDefaultReasonPhrase
+{
+    public abstract function statusCode(): int;
+
+    public function reasonPhrase(): string
+    {
+        return match ($this->statusCode()) {
+            100	=> "Continue",
+            101 => "Switching Protocols",
+            102 => "Processing",
+            103 => "Early Hints",
+
+            200 => "OK",
+            201 => "Created",
+            202 => "Accepted",
+            203 => "Non-Authoritative Information",
+            204 => "No Content",
+            205 => "Reset Content",
+            206 => "Partial Content",
+            207 => "Multi-Status",
+            208 => "Already Reported",
+
+            226 => "IM Used",
+
+            300 => "Multiple Choices",
+            301 => "Moved Permanently",
+            302 => "Found",
+            303 => "See Other",
+            304 => "Not Modified",
+            305 => "Use Proxy",
+            306 => "(Unused)",
+            307 => "Temporary Redirect",
+            308 => "Permanent Redirect",
+
+            400 => "Bad Request",
+            401 => "Unauthorized",
+            402 => "Payment Required",
+            403 => "Forbidden",
+            404 => "Not Found",
+            405 => "Method Not Allowed",
+            406 => "Not Acceptable",
+            407 => "Proxy Authentication Required",
+            408 => "Request Timeout",
+            409 => "Conflict",
+            410 => "Gone",
+            411 => "Length Required",
+            412 => "Precondition Failed",
+            413 => "Content Too Large",
+            414 => "URI Too Long",
+            415 => "Unsupported Media Type",
+            416 => "Range Not Satisfiable",
+            417 => "Expectation Failed",
+            418 => "(Unused)",
+
+            421 => "Misdirected Request",
+            422 => "Unprocessable Content",
+            423 => "Locked",
+            424 => "Failed Dependency",
+            425 => "Too Early",
+            426 => "Upgrade Required",
+
+            428 => "Precondition Required",
+            429 => "Too Many Requests",
+
+            431 => "Request Header Fields Too Large",
+
+            451 => "Unavailable For Legal Reasons",
+
+            500 => "Internal Server Error",
+            501 => "Not Implemented",
+            502 => "Bad Gateway",
+            503 => "Service Unavailable",
+            504 => "Gateway Timeout",
+            505 => "HTTP Version Not Supported",
+            506 => "Variant Also Negotiates",
+            507 => "Insufficient Storage",
+            508 => "Loop Detected",
+
+            510 => "Not Extended",
+            511 => "Network Authentication Required",
+
+            default => "Unknown",
+        };
+    }
+}

--- a/src/Responses/HasDefaultReasonPhrase.php
+++ b/src/Responses/HasDefaultReasonPhrase.php
@@ -34,7 +34,6 @@ trait HasDefaultReasonPhrase
             303 => "See Other",
             304 => "Not Modified",
             305 => "Use Proxy",
-            306 => "(Unused)",
             307 => "Temporary Redirect",
             308 => "Permanent Redirect",
 
@@ -56,7 +55,7 @@ trait HasDefaultReasonPhrase
             415 => "Unsupported Media Type",
             416 => "Range Not Satisfiable",
             417 => "Expectation Failed",
-            418 => "(Unused)",
+            418 => "I'm a teapot",
 
             421 => "Misdirected Request",
             422 => "Unprocessable Content",

--- a/src/Responses/HasDefaultReasonPhrase.php
+++ b/src/Responses/HasDefaultReasonPhrase.php
@@ -6,12 +6,13 @@ namespace Bead\Responses;
 
 trait HasDefaultReasonPhrase
 {
-    public abstract function statusCode(): int;
+    abstract public function statusCode(): int;
 
+    /** Fetch the default reason phrase for the response's HTTP status. */
     public function reasonPhrase(): string
     {
         return match ($this->statusCode()) {
-            100	=> "Continue",
+            100 => "Continue",
             101 => "Switching Protocols",
             102 => "Processing",
             103 => "Early Hints",

--- a/src/Responses/NaivelySendsContent.php
+++ b/src/Responses/NaivelySendsContent.php
@@ -10,6 +10,7 @@ use Bead\Exceptions\Http\HttpException;
 trait NaivelySendsContent
 {
     use SendsHeaders;
+    use SanitisesReasonPhrase;
 
     /**
      * Constrain the trait to classes that implement this method.
@@ -42,9 +43,7 @@ trait NaivelySendsContent
      */
     public function send(): void
     {
-
-        $reasonPhrase = str_replace(["\n", "\r",], " ", $this->reasonPhrase());
-        header("HTTP/1.1 {$this->statusCode()} {$reasonPhrase}");
+        header("HTTP/1.1 {$this->statusCode()} {$this->sanitisedReasonPhrase()}");
         header("content-type: {$this->contentType()}", true);
 
         foreach ($this->headers() as $header => $value) {

--- a/src/Responses/NaivelySendsContent.php
+++ b/src/Responses/NaivelySendsContent.php
@@ -42,7 +42,9 @@ trait NaivelySendsContent
      */
     public function send(): void
     {
-        http_response_code($this->statusCode());
+
+        $reasonPhrase = str_replace(["\n", "\r",], " ", $this->reasonPhrase());
+        header("HTTP/1.1 {$this->statusCode()} {$reasonPhrase}");
         header("content-type: {$this->contentType()}", true);
 
         foreach ($this->headers() as $header => $value) {

--- a/src/Responses/RedirectResponse.php
+++ b/src/Responses/RedirectResponse.php
@@ -9,6 +9,7 @@ use Bead\Contracts\Response;
  */
 class RedirectResponse implements Response
 {
+    use HasDefaultReasonPhrase;
     use DoesntHaveContent;
     use SendsHeaders;
 

--- a/src/Responses/SanitisesReasonPhrase.php
+++ b/src/Responses/SanitisesReasonPhrase.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Responses;
+
+trait SanitisesReasonPhrase
+{
+    public abstract function reasonPhrase(): string;
+
+    public function sanitisedReasonPhrase(): string
+    {
+        return str_replace(["\r", "\n",], " ", $this->reasonPhrase());
+    }
+}

--- a/src/Responses/SanitisesReasonPhrase.php
+++ b/src/Responses/SanitisesReasonPhrase.php
@@ -6,8 +6,9 @@ namespace Bead\Responses;
 
 trait SanitisesReasonPhrase
 {
-    public abstract function reasonPhrase(): string;
+    abstract public function reasonPhrase(): string;
 
+    /** Sanitise the reason phrase for use in the HTTP status header. */
     public function sanitisedReasonPhrase(): string
     {
         return str_replace(["\r", "\n",], " ", $this->reasonPhrase());

--- a/src/View.php
+++ b/src/View.php
@@ -8,6 +8,7 @@ use Bead\Exceptions\ViewNotFoundException;
 use Bead\Exceptions\ViewRenderingException;
 use Bead\Facades\WebApplication as WebApp;
 use Bead\Responses\DoesntHaveHeaders;
+use Bead\Responses\HasDefaultReasonPhrase;
 use Bead\Responses\NaivelySendsContent;
 use Bead\Web\Application as WebApplication;
 use InvalidArgumentException;
@@ -102,6 +103,7 @@ use function Bead\Helpers\Str\html;
  */
 class View implements Response
 {
+    use HasDefaultReasonPhrase;
     use DoesntHaveHeaders;
     use NaivelySendsContent;
 

--- a/test/Responses/CanSetContentTypeTest.php
+++ b/test/Responses/CanSetContentTypeTest.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BeadTests\Responses;
 
-use Bead\Contracts\Response;
 use Bead\Responses\CanSetContentType;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 final class CanSetContentTypeTest extends TestCase
 {
     /** Helper to create a new instance of a class that imports the trait under test. */
-    private function createInstance(): mixed
+    private static function createInstance(): object
     {
         return new class
         {
@@ -18,15 +19,15 @@ final class CanSetContentTypeTest extends TestCase
     }
 
     /** Ensure we can fetch the content-type. */
-    public function testStatusCode(): void
+    public function testContentType1(): void
     {
-        self::assertEquals("application/octet-stream", $this->createInstance()->contentType());
+        self::assertEquals("application/octet-stream", self::createInstance()->contentType());
     }
 
     /** Ensure we can set the content-type. */
-    public function testSetStatusCode(): void
+    public function testSetContentType1(): void
     {
-        $instance = $this->createInstance();
+        $instance = self::createInstance();
         $instance->setContentType("application/json");
         self::assertEquals("application/json", $instance->contentType());
     }

--- a/test/Responses/CanSetReasonPhraseTest.php
+++ b/test/Responses/CanSetReasonPhraseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Responses;
+
+use Bead\Responses\CanSetReasonPhrase;
+use BeadTests\Framework\TestCase;
+
+final class CanSetReasonPhraseTest extends TestCase
+{
+    /** Create an anonymous object that imports the trait under test. */
+    private static function createInstance(): object
+    {
+        return new class
+        {
+            use CanSetReasonPhrase;
+
+            public function __construct()
+            {
+                $this->m_reasonPhrase = "OK";
+            }
+        };
+    }
+
+
+    /** Ensure we can fetch the reason phrase. */
+    public function testReasonPhrase1(): void
+    {
+        self::assertEquals("OK", self::createInstance()->reasonPhrase());
+    }
+
+    /** Ensure we can set the reason phrase. */
+    public function testSetReasonPhrase1(): void
+    {
+        $instance = self::createInstance();
+        $instance->setReasonPhrase("Not OK");
+        self::assertEquals("Not OK", $instance->reasonPhrase());
+    }
+}

--- a/test/Responses/CanSetStatusCodeTest.php
+++ b/test/Responses/CanSetStatusCodeTest.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BeadTests\Responses;
 
-use Bead\Contracts\Response;
 use Bead\Responses\CanSetStatusCode;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 final class CanSetStatusCodeTest extends TestCase
 {
     /** Helper to create a new instance of a class that imports the trait under test. */
-    private function createInstance(): mixed
+    private static function createInstance(): object
     {
         return new class
         {
@@ -24,15 +25,15 @@ final class CanSetStatusCodeTest extends TestCase
 
 
     /** Ensure we can fetch the status code. */
-    public function testStatusCode(): void
+    public function testStatusCode1(): void
     {
-        self::assertEquals(200, $this->createInstance()->statusCode());
+        self::assertEquals(200, self::createInstance()->statusCode());
     }
 
     /** Ensure we can set the status code. */
-    public function testSetStatusCode(): void
+    public function testSetStatusCode1(): void
     {
-        $instance = $this->createInstance();
+        $instance = self::createInstance();
         $instance->setStatusCode(400);
         self::assertEquals(400, $instance->statusCode());
     }

--- a/test/Responses/DoesntHaveContentTest.php
+++ b/test/Responses/DoesntHaveContentTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace BeadTests\Responses;
 
 use Bead\Responses\DoesntHaveContent;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 class DoesntHaveContentTest extends TestCase
 {
     /** Helper to create a new instance of a class that imports the trait under test. */
-    private function createInstance(): mixed
+    private static function createInstance(): object
     {
         return new class
         {
@@ -19,14 +19,14 @@ class DoesntHaveContentTest extends TestCase
     }
 
     /** Ensure the content-type is an empty string. */
-    public function testContentType(): void
+    public function testContentType1(): void
     {
-        self::assertEquals("", $this->createInstance()->contentType());
+        self::assertEquals("", self::createInstance()->contentType());
     }
 
     /** Ensure the content is an empty string. */
-    public function testContent(): void
+    public function testContent1(): void
     {
-        self::assertEquals("", $this->createInstance()->content());
+        self::assertEquals("", self::createInstance()->content());
     }
 }

--- a/test/Responses/DoesntHaveHeadersTest.php
+++ b/test/Responses/DoesntHaveHeadersTest.php
@@ -10,7 +10,7 @@ use BeadTests\Framework\TestCase;
 class DoesntHaveHeadersTest extends TestCase
 {
     /** Helper to create a new instance of a class that imports the trait under test. */
-    private function createInstance(): mixed
+    private static function createInstance(): object
     {
         return new class
         {
@@ -19,8 +19,8 @@ class DoesntHaveHeadersTest extends TestCase
     }
 
     /** Ensure the headers are an empty array. */
-    public function testHeaders(): void
+    public function testHeaders1(): void
     {
-        self::assertEquals([], $this->createInstance()->headers());
+        self::assertEquals([], self::createInstance()->headers());
     }
 }

--- a/test/Responses/HasDefaultReasonPhraseTest.php
+++ b/test/Responses/HasDefaultReasonPhraseTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Responses;
+
+use Bead\Responses\HasDefaultReasonPhrase;
+use BeadTests\Framework\TestCase;
+
+class HasDefaultReasonPhraseTest extends TestCase
+{
+    /** Create an anonymous object that imports the trait under test. */
+    private static function createInstance(int $statusCode): object
+    {
+        return new class($statusCode)
+        {
+            use HasDefaultReasonPhrase;
+
+            private int $statusCode;
+
+            public function __construct(int $statusCode)
+            {
+                $this->statusCode = $statusCode;
+            }
+
+            public function statusCode(): int
+            {
+                return $this->statusCode;
+            }
+        };
+    }
+
+    public static function dataForTestReasonPhrase1(): iterable
+    {
+        yield "status-100" => [100, "Continue",];
+        yield "status-101" => [101, "Switching Protocols",];
+        yield "status-102" => [102, "Processing",];
+        yield "status-103" => [103, "Early Hints",];
+
+        yield "status-200" => [200, "OK",];
+        yield "status-201" => [201, "Created",];
+        yield "status-202" => [202, "Accepted",];
+        yield "status-203" => [203, "Non-Authoritative Information",];
+        yield "status-204" => [204, "No Content",];
+        yield "status-205" => [205, "Reset Content",];
+        yield "status-206" => [206, "Partial Content",];
+        yield "status-207" => [207, "Multi-Status",];
+        yield "status-208" => [208, "Already Reported",];
+
+        yield "status-226" => [226, "IM Used",];
+
+        yield "status-300" => [300, "Multiple Choices",];
+        yield "status-301" => [301, "Moved Permanently",];
+        yield "status-302" => [302, "Found",];
+        yield "status-303" => [303, "See Other",];
+        yield "status-304" => [304, "Not Modified",];
+        yield "status-305" => [305, "Use Proxy",];
+        yield "status-307" => [307, "Temporary Redirect",];
+        yield "status-308" => [308, "Permanent Redirect",];
+
+        yield "status-400" => [400, "Bad Request",];
+        yield "status-401" => [401, "Unauthorized",];
+        yield "status-402" => [402, "Payment Required",];
+        yield "status-403" => [403, "Forbidden",];
+        yield "status-404" => [404, "Not Found",];
+        yield "status-405" => [405, "Method Not Allowed",];
+        yield "status-406" => [406, "Not Acceptable",];
+        yield "status-407" => [407, "Proxy Authentication Required",];
+        yield "status-408" => [408, "Request Timeout",];
+        yield "status-409" => [409, "Conflict",];
+        yield "status-410" => [410, "Gone",];
+        yield "status-411" => [411, "Length Required",];
+        yield "status-412" => [412, "Precondition Failed",];
+        yield "status-413" => [413, "Content Too Large",];
+        yield "status-414" => [414, "URI Too Long",];
+        yield "status-415" => [415, "Unsupported Media Type",];
+        yield "status-416" => [416, "Range Not Satisfiable",];
+        yield "status-417" => [417, "Expectation Failed",];
+        yield "status-418" => [418, "I'm a teapot",];
+
+        yield "status-421" => [421, "Misdirected Request",];
+        yield "status-422" => [422, "Unprocessable Content",];
+        yield "status-423" => [423, "Locked",];
+        yield "status-424" => [424, "Failed Dependency",];
+        yield "status-425" => [425, "Too Early",];
+        yield "status-426" => [426, "Upgrade Required",];
+
+        yield "status-428" => [428, "Precondition Required",];
+        yield "status-429" => [429, "Too Many Requests",];
+
+        yield "status-431" => [431, "Request Header Fields Too Large",];
+
+        yield "status-451" => [451, "Unavailable For Legal Reasons",];
+
+        yield "status-500" => [500, "Internal Server Error",];
+        yield "status-501" => [501, "Not Implemented",];
+        yield "status-502" => [502, "Bad Gateway",];
+        yield "status-503" => [503, "Service Unavailable",];
+        yield "status-504" => [504, "Gateway Timeout",];
+        yield "status-505" => [505, "HTTP Version Not Supported",];
+        yield "status-506" => [506, "Variant Also Negotiates",];
+        yield "status-507" => [507, "Insufficient Storage",];
+        yield "status-508" => [508, "Loop Detected",];
+
+        yield "status-510" => [510, "Not Extended",];
+        yield "status-511" => [511, "Network Authentication Required",];
+    }
+
+    /**
+     * Ensure we get the expected reason phrases for defined HTTP status codes.
+     *
+     * @dataProvider dataForTestReasonPhrase1
+     */
+    public function testReasonPhrase1(int $statusCode, string $expected): void
+    {
+        self::assertEquals($expected, self::createInstance($statusCode)->reasonPhrase());
+    }
+
+    public static function dataForTestReasonPhrase2(): iterable
+    {
+        for ($statusCode = 0; $statusCode < 100; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 104; $statusCode < 200; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 209; $statusCode < 226; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 227; $statusCode < 300; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 309; $statusCode < 400; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 419; $statusCode < 421; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        yield "427" => [427,];
+        yield "430" => [430,];
+
+        for ($statusCode = 432; $statusCode < 451; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        for ($statusCode = 452; $statusCode < 500; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+
+        yield "509" => [509,];
+
+        for ($statusCode = 512; $statusCode < 600; ++$statusCode) {
+            yield (string) $statusCode => [$statusCode,];
+        }
+    }
+
+    /**
+     * Ensure "Unknown" is returned for unknown status codes.
+     *
+     * @dataProvider dataForTestReasonPhrase2
+     */
+    public function testReasonPhrase2(int $statusCode): void
+    {
+        self::assertEquals("Unknown", self::createInstance($statusCode)->reasonPhrase());
+    }
+}

--- a/test/Responses/HasDefaultReasonPhraseTest.php
+++ b/test/Responses/HasDefaultReasonPhraseTest.php
@@ -12,7 +12,7 @@ class HasDefaultReasonPhraseTest extends TestCase
     /** Create an anonymous object that imports the trait under test. */
     private static function createInstance(int $statusCode): object
     {
-        return new class($statusCode)
+        return new class ($statusCode)
         {
             use HasDefaultReasonPhrase;
 

--- a/test/Responses/SanitisesReasonPhraseTest.php
+++ b/test/Responses/SanitisesReasonPhraseTest.php
@@ -12,7 +12,7 @@ class SanitisesReasonPhraseTest extends TestCase
     /** Create an anonymous object that imports the trait under test. */
     private static function createInstance(string $reasonPhrase): object
     {
-        return new class($reasonPhrase)
+        return new class ($reasonPhrase)
         {
             use SanitisesReasonPhrase;
 

--- a/test/Responses/SanitisesReasonPhraseTest.php
+++ b/test/Responses/SanitisesReasonPhraseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Responses;
+
+use Bead\Responses\SanitisesReasonPhrase;
+use BeadTests\Framework\TestCase;
+
+class SanitisesReasonPhraseTest extends TestCase
+{
+    /** Create an anonymous object that imports the trait under test. */
+    private static function createInstance(string $reasonPhrase): object
+    {
+        return new class($reasonPhrase)
+        {
+            use SanitisesReasonPhrase;
+
+            private string $reasonPhrase;
+
+            public function __construct(string $reasonPhrase)
+            {
+                $this->reasonPhrase = $reasonPhrase;
+            }
+
+            public function reasonPhrase(): string
+            {
+                return $this->reasonPhrase;
+            }
+        };
+    }
+
+    public static function dataForTestSanitisedReasonPhrase1(): iterable
+    {
+        yield "empty" => ["", "",];
+        yield "whitespace" => ["  ", "  ",];
+        yield "whitesapce-cr" => [" \r ", "   ",];
+        yield "whitesapce-lf" => [" \n ", "   ",];
+        yield "whitesapce-crlf" => [" \r\n ", "    ",];
+        yield "whitesapce-lfcr" => [" \n\r ", "    ",];
+        yield "whitesapce-cr-whitespace-lf" => [" \r \n ", "     ",];
+        yield "whitesapce-lf-whitespace-cr" => [" \n \r ", "     ",];
+        yield "text-cr" => ["reason\r", "reason ",];
+        yield "text-lf" => ["reason\n", "reason ",];
+        yield "text-crlf" => ["reason\r\n", "reason  ",];
+        yield "text-crlf-embedded" => ["rea\r\nson", "rea  son",];
+    }
+
+    /**
+     * Ensure the reason phrase is sanitised as expected.
+     *
+     * @dataProvider dataForTestSanitisedReasonPhrase1
+     */
+    public function testSanitisedReasonPhrase1(string $reasonPhrase, string $expected): void
+    {
+        self::assertEquals($expected, self::createInstance($reasonPhrase)->sanitisedReasonPhrase());
+    }
+}

--- a/test/Responses/SendsHeadersTest.php
+++ b/test/Responses/SendsHeadersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BeadTests\Responses;
 
 use Bead\Responses\SendsHeaders;
@@ -14,7 +16,7 @@ final class SendsHeadersTest extends TestCase
     ];
 
     /** Helper to create a new instance of a class that imports the trait under test. */
-    private function createInstance(): mixed
+    private static function createInstance(): object
     {
         return new class
         {
@@ -54,7 +56,7 @@ final class SendsHeadersTest extends TestCase
             }
         );
 
-        $instance = new XRay($this->createInstance());
+        $instance = new XRay(self::createInstance());
         $instance->sendHeaders();
         self::assertEmpty($expectedHeaders, "Not all expected headers were generated.");
     }


### PR DESCRIPTION
Make responses provide the HTTP reason phrase as well as the status code. For convenience, provides a trait that sets the default reason phrase for all defined HTTP response codes.