### PR TITLE
BEAD-199 fix missing type hints in UriSigner.

### DIFF
--- a/src/Contracts/UriSigner.php
+++ b/src/Contracts/UriSigner.php
@@ -5,7 +5,7 @@ namespace Bead\Contracts;
 use DateTimeInterface;
 
 /**
- * Interface for imlementations of signed URI generators.
+ * Interface for implementations of signed URI generators.
  */
 interface UriSigner
 {
@@ -16,7 +16,7 @@ interface UriSigner
      *
      * @param string $secret The secret.
      *
-     * @return $this A UriSigner for further methdo chaining.
+     * @return $this A UriSigner for further method chaining.
      */
     public function usingSecret(string $secret): self;
 
@@ -44,7 +44,7 @@ interface UriSigner
     /**
      * Verify a signed URI.
      *
-     * @param string $uri The signed URI
+     * @param string $signedUri The signed URI
      * @param int|DateTimeInterface|null $at The point in time at which to verify the URI. Defaults to `null`, which
      * means verify at the current time.
      *

--- a/src/UriSigner.php
+++ b/src/UriSigner.php
@@ -18,7 +18,7 @@ class UriSigner implements UriSignerContract
     /**
      * The minimum required length for a secret.
      *
-     * This is not a recommendataion - it's not a very secure length - but the minimum that will be accepted.
+     * This is not a recommendation - it's not a very secure length - but the minimum that will be accepted.
      */
     public const MinimumSecretLength = 6;
 
@@ -199,13 +199,12 @@ class UriSigner implements UriSignerContract
      * @return string The signed URI.
      * @throws UriSignerException if the secret has not been set to a valid value
      */
-    public function sign(string $uri, array $parameters, $expires): string
+    public function sign(string $uri, array $parameters, int|DateTimeInterface $expires): string
     {
-        assert($expires instanceof DateTimeInterface || is_int($expires), new TypeError("Argument for parameter #3 '\$expires' is not valied - expected DateTimeInterface or int."));
         $parameters["expires"] = ($expires instanceof DateTimeInterface ? $expires->getTimestamp() : $expires);
         $queryString = self::queryString($parameters);
 
-        if (false === strpos($uri, "?")) {
+        if (!str_contains($uri, "?")) {
             $uri = "{$uri}?{$queryString}";
         } else {
             $uri = "{$uri}&{$queryString}";
@@ -223,16 +222,12 @@ class UriSigner implements UriSignerContract
      *
      * @return bool `true` if the signature is verified, `false` if not.
      */
-    public function verify(string $signedUri, $at = null): bool
+    public function verify(string $signedUri, int|DateTimeInterface|null $at = null): bool
     {
         if (!isset($at)) {
             $at = time();
-        } else {
-            assert($at instanceof DateTimeInterface || is_int($at), new TypeError("Argument for parameter #2 '\$at' is not valied - expected DateTimeInterface or int."));
-
-            if ($at instanceof DateTimeInterface) {
-                $at = $at->getTimestamp();
-            }
+        } elseif ($at instanceof DateTimeInterface) {
+            $at = $at->getTimestamp();
         }
 
         // NOTE signature MUST always be last URI parameter, this is mandated in sign() above

--- a/test/UriSignerTest.php
+++ b/test/UriSignerTest.php
@@ -6,7 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use Bead\Exceptions\UriSignerException;
 use Bead\UriSigner;
-use PHPUnit\Framework\TestCase;
+use BeadTests\Framework\TestCase;
 
 class UriSignerTest extends TestCase
 {
@@ -38,45 +38,36 @@ class UriSignerTest extends TestCase
         unset($this->m_signer);
     }
 
-    /**
-     * Ensure the default constructor initialises the signer with the expected state.
-     */
-    public function testDefaultConstructor(): void
+    /** Ensure the default constructor initialises the signer with the expected state. */
+    public function testConstructor1(): void
     {
         $signer = new UriSigner();
         self::assertEquals(UriSigner::DefaultAlgorithm, $signer->algorithm());
         self::assertEquals("", $signer->secret());
     }
 
-    /**
-     * Ensure we can set a hashing algorithm in the constructor.
-     */
-    public function testConstructorWithAlgorithm(): void
+    /** Ensure we can set a hashing algorithm in the constructor. */
+    public function testConstructor2(): void
     {
         $signer = new UriSigner("md5");
         self::assertEquals("md5", $signer->algorithm());
         self::assertEquals("", $signer->secret());
     }
 
-    /**
-     * Ensure setting an unsupported algorithm in the constructor throws.
-     */
-    public function testConstructorWithUnsupportedAlgorithm(): void
+    /** Ensure setting an unsupported algorithm in the constructor throws. */
+    public function testConstructor3(): void
     {
         $this->expectException(UriSignerException::class);
         new UriSigner("_0987fads089yhn 2q37&^%&*%^&");
     }
 
-    /**
-     * Ensure we can set the hashing algorithm.
-     */
-    public function testSetAlgorithm(): void
+    /** Ensure we can set the hashing algorithm. */
+    public function testSetAlgorithm1(): void
     {
         $algos = hash_hmac_algos();
 
         if (empty($algos)) {
-            $this->markTestSkipped("hash_hmac_algos() returned no supported algorithms - URI signing is not possible.");
-            return;
+            self::markTestSkipped("hash_hmac_algos() returned no supported algorithms - URI signing is not possible.");
         }
 
         foreach ($algos as $algo) {
@@ -85,10 +76,8 @@ class UriSignerTest extends TestCase
         }
     }
 
-    /**
-     * Ensure we can retrieve the hashing algorithm.
-     */
-    public function testAlgorithm(): void
+    /** Ensure we can retrieve the hashing algorithm. */
+    public function testAlgorithm1(): void
     {
         self::assertEquals(UriSigner::DefaultAlgorithm, $this->m_signer->algorithm());
 
@@ -98,10 +87,8 @@ class UriSignerTest extends TestCase
         }
     }
 
-    /**
-     * Ensure setting the secret is immutable.
-     */
-    public function testUsingSecret(): void
+    /** Ensure setting the secret is immutable. */
+    public function testUsingSecret1(): void
     {
         self::assertNotEquals("some-other-secret", $this->m_signer->secret());
         self::assertEquals(self::Secret, $this->m_signer->secret());
@@ -112,20 +99,16 @@ class UriSignerTest extends TestCase
         self::assertEquals("some-other-secret", $actual->secret());
     }
 
-    /**
-     * Ensure secret() returns the expected secret.
-     */
-    public function testSecret(): void
+    /** Ensure secret() returns the expected secret. */
+    public function testSecret1(): void
     {
         self::assertEquals(self::Secret, $this->m_signer->secret());
         $signer = $this->m_signer->usingSecret("some-other-secret");
         self::assertEquals("some-other-secret", $signer->secret());
     }
 
-    /**
-     * Ensure sign() produces the expected URIs when given timestamps and DateTime objects as expiry times.
-     */
-    public function testSign(): void
+    /** Ensure sign() produces the expected URIs when given timestamps and DateTime objects as expiry times. */
+    public function testSign1(): void
     {
         $expected = "https://bead.framework/protected/uri?id=1&token=XF12jka8hbyHIofu6dSauioCHUIsfui754g&expires=1667232000&signature=850a5ede2b7af8a7354a443171aa67a90bddcbaf";
         $actual = $this->m_signer->sign("https://bead.framework/protected/uri", self::Parameters, self::ExpiresTimestamp);
@@ -136,65 +119,51 @@ class UriSignerTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /**
-     * Ensure verify() can correctly verify a signature.
-     */
-    public function testVerify(): void
+    /** Ensure verify() can correctly verify a signature. */
+    public function testVerify1(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], PHP_INT_MAX);
         self::assertTrue($this->m_signer->verify($signed));
     }
 
-    /**
-     * Ensure specifying a verification time with a timestamp verifies as expected.
-     */
-    public function testVerifyWithTimestamp(): void
+    /** Ensure specifying a verification time with a timestamp verifies as expected. */
+    public function testVerify2(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp);
         self::assertTrue($this->m_signer->verify($signed, self::ExpiresTimestamp - 1));
     }
 
-    /**
-     * Ensure specifying a verification time with a DateTime object verifies as expected.
-     */
-    public function testVerifyWithDateTime(): void
+    /** Ensure specifying a verification time with a DateTime object verifies as expected. */
+    public function testVerify3(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp + (60 * 60 * 24 * 7));
         self::assertTrue($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
     }
 
-    /**
-     * Ensure mismatching signatures result in verification failure.
-     */
-    public function testVerifyRejectsBadSignature(): void
+    /** Ensure mismatching signatures result in verification failure. */
+    public function testVerify4(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], PHP_INT_MAX);
         self::assertFalse($this->m_signer->verify("{$signed}x"));
         self::assertFalse($this->m_signer->verify(substr($signed, 0, -1)));
     }
 
-    /**
-     * Ensure we can specify a verification test time using a timestamp and get a verification fail when expected.
-     */
-    public function testVerifyRejectsExpiredTimestamp(): void
+    /** Ensure we can specify a verification test time using a timestamp and get a verification fail when expected. */
+    public function testVerify5(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp);
         self::assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp + 1));
     }
 
-    /**
-     * Ensure we can specify a verification test time using a DateTime object and get a verification fail when expected.
-     */
-    public function testVerifyRejectsExpiredDateTime(): void
+    /** Ensure we can specify a verification test time using a DateTime object and get a verification fail when expected. */
+    public function testVerify6(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], self::ExpiresTimestamp - 1);
         self::assertFalse($this->m_signer->verify($signed, new DateTime(self::ExpiresDateTime)));
     }
 
-    /**
-     * Ensure expired signed URIs are rejected when the time to verify at is now.
-     */
-    public function testVerifyRejectsExpiredNow(): void
+    /** Ensure expired signed URIs are rejected when the time to verify at is now. */
+    public function testVerify7(): void
     {
         $now = time() - 1;
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], $now);
@@ -207,7 +176,7 @@ class UriSignerTest extends TestCase
      * Third parties must not be able to render expired signed URIs valid by chaning the timestamp - doing so should
      * change the expected signature, causing the URI to fail to verify.
      */
-    public function testVerifyRejectsAlteredTimestammp(): void
+    public function testVerify8(): void
     {
         $expires = self::ExpiresTimestamp - 1;
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", [], $expires);
@@ -217,10 +186,8 @@ class UriSignerTest extends TestCase
         self::assertFalse($this->m_signer->verify($signed, self::ExpiresTimestamp));
     }
 
-    /**
-     * Ensure signed URIs aren't verified when the order of the URI parameters has been changed.
-     */
-    public function testVerifyRejectsWitReorderedParameters(): void
+    /** Ensure signed URIs aren't verified when the order of the URI parameters has been changed. */
+    public function testVerify9(): void
     {
         $signed = $this->m_signer->sign("http://bead.framework/protected/uri", self::Parameters, self::ExpiresTimestamp);
         $signature = substr($signed, strpos($signed, "&signature=") + 11);


### PR DESCRIPTION
Fix typos and parameter names in contract. Fix typos and missing type specifications in implementation. Make test consistent with other tests.