### PR TITLE
BEAD-202 Add static declaration to facade method annotations

### DIFF
--- a/src/Facades/Hash.php
+++ b/src/Facades/Hash.php
@@ -8,8 +8,8 @@ use Bead\Contracts\Hasher;
 use Bead\Facades\ApplicationServiceFacade;
 
 /**
- * @method string hash(string $value)
- * @method string verify(string $value, string $hash)
+ * @method static string hash(string $value)
+ * @method static string verify(string $value, string $hash)
  */
 class Hash extends ApplicationServiceFacade
 {

--- a/src/Facades/Mail.php
+++ b/src/Facades/Mail.php
@@ -8,7 +8,7 @@ use Bead\Contracts\Email\Transport as TransportContract;
 use Bead\Contracts\Email\Message as MessageContract;
 
 /**
- * @method void send(MessageContract $message)
+ * @method static void send(MessageContract $message)
  */
 class Mail extends ApplicationServiceFacade
 {

--- a/src/Facades/WebApplication.php
+++ b/src/Facades/WebApplication.php
@@ -17,20 +17,20 @@ use function method_exists;
  * @mixin BeadWebApplication
  * @psalm-seal-methods
  *
- * @method bool isRunning()
- * @method string routesDirectory()
- * @method string pluginsDirectory()
- * @method string pluginsNamespace()
- * @method string[] loadedPlugins()
- * @method Plugin|null pluginByName(string $name)
- * @method void setRouter(RouterContract $router)
- * @method RouterContract router()
- * @method void sendResponse(ResponseContract $response)
- * @method Request request()
- * @method string csrf()
- * @method string regenerateCsrf()
- * @method ResponseContract handleRequest(Request $request)
- * @method int exec()
+ * @method static bool isRunning()
+ * @method static string routesDirectory()
+ * @method static string pluginsDirectory()
+ * @method static string pluginsNamespace()
+ * @method static string[] loadedPlugins()
+ * @method static Plugin|null pluginByName(string $name)
+ * @method static void setRouter(RouterContract $router)
+ * @method static RouterContract router()
+ * @method static void sendResponse(ResponseContract $response)
+ * @method static Request request()
+ * @method static string csrf()
+ * @method static string regenerateCsrf()
+ * @method static ResponseContract handleRequest(Request $request)
+ * @method static int exec()
  */
 class WebApplication extends Application
 {

--- a/test/Encryption/OpenSsl/EncryptsTest.php
+++ b/test/Encryption/OpenSsl/EncryptsTest.php
@@ -74,7 +74,7 @@ class EncryptsTest extends TestCase
     /** Ensure encrypt() throws when base64 encoding fails. */
     public function testEncrypt4(): void
     {
-        self::mockFunction("base64_encode", fn(string $data): string|false => false);
+        self::mockFunction("base64_encode", fn (string $data): string|false => false);
         self::expectException(EncryptionException::class);
         self::expectExceptionMessage("Unable to encrypt data");
         $this->instance->encrypt(self::RawData);


### PR DESCRIPTION
For `Hash`, `Mail` and `WebApplication` facades. Also fix CS issue in `EncryptsTest` (missing space after `fn` keyword).