### PR TITLE
BEAD-209 Start a new session if session facade encounters a destroyed session

### DIFF
--- a/src/Facades/Session.php
+++ b/src/Facades/Session.php
@@ -5,6 +5,7 @@ namespace Bead\Facades;
 use BadMethodCallException;
 use Bead\Exceptions\Session\ExpiredSessionIdUsedException;
 use Bead\Exceptions\Session\InvalidSessionHandlerException;
+use Bead\Exceptions\Session\SessionDestroyedException;
 use Bead\Exceptions\Session\SessionException;
 use Bead\Exceptions\Session\SessionExpiredException;
 use Bead\Exceptions\Session\SessionNotFoundException;
@@ -72,6 +73,8 @@ final class Session
         } catch (SessionNotFoundException $err) {
             self::$session = new BeadSession();
         } catch (SessionExpiredException $err) {
+            self::$session = new BeadSession();
+        } catch (SessionDestroyedException $err) {
             self::$session = new BeadSession();
         }
 


### PR DESCRIPTION
At present, the Session facade's `start()` method will leak a `SessionDestroyedException` if one occurs. Like `SessionNotFoundException` and `SessionExpiredException`, the application should just initialise a new session in these circumstances (unlike the other session exceptions which indicate a fatal or security exception). This PR ensures that start() will catch `SessionDestroyedException`s and start a new session instead of forwarding the exception.