### PR TITLE
BEAD-201 Fix misnamed test tear down methods.

### DIFF
--- a/test/Facades/HashTest.php
+++ b/test/Facades/HashTest.php
@@ -31,7 +31,7 @@ final class HashTest extends TestCase
             ->byDefault();
     }
 
-    public function tearDonw(): void
+    public function tearDown(): void
     {
         unset($this->app, $this->hasher);
         Mockery::close();

--- a/test/Hashers/ArgonHasherTest.php
+++ b/test/Hashers/ArgonHasherTest.php
@@ -17,7 +17,7 @@ final class ArgonHasherTest extends TestCase
         $this->hasher = new ArgonHasher();
     }
 
-    public function tearDonw(): void
+    public function tearDown(): void
     {
         unset($this->hasher);
         parent::tearDown();

--- a/test/Hashers/BcryptHasherTest.php
+++ b/test/Hashers/BcryptHasherTest.php
@@ -17,7 +17,7 @@ final class BcryptHasherTest extends TestCase
         $this->hasher = new BcryptHasher();
     }
 
-    public function tearDonw(): void
+    public function tearDown(): void
     {
         unset($this->hasher);
         parent::tearDown();

--- a/test/Validation/ValidatorTest.php
+++ b/test/Validation/ValidatorTest.php
@@ -19,13 +19,10 @@ use ReflectionNamedType;
 
 final class ValidatorTest extends TestCase
 {
-    public function setUp(): void
-    {
-    }
-
-    public function tearDonw(): void
+    public function tearDown(): void
     {
         Mockery::close();
+        parent::tearDown();
     }
 
     private static function mockNamedType(string $typeName): ReflectionNamedType


### PR DESCRIPTION
Some tests had tearDonw() methods instead of tearDown().