### PR TITLE
BEAD-203 use XRay helper instead of reflection directly in tests where possible

### DIFF
--- a/src/Testing/XRay.php
+++ b/src/Testing/XRay.php
@@ -32,11 +32,13 @@ class XRay
     /** @var string[] Cache of resolved public methods. */
     private array $m_publicMethods = [];
 
-    /** @var ReflectionMethod[] Cache of the resolved ReflectionMethod instances for inaccessible methods. */
+    /**
+     * @var ReflectionMethod[] Cache of the resolved ReflectionMethod instances for inaccessible methods.
+     */
     private array $m_xRayedMethods = [];
 
     /** @var string[] Cache of methods that cannot be resolved. */
-    private array $m_unresolvedMethods = [];
+    private array $m_unresolvabledMethods = [];
 
     /** @var string[] Cache of resolved public properties. */
     private array $m_publicProperties = [];
@@ -45,7 +47,7 @@ class XRay
     private array $m_xRayedProperties = [];
 
     /** @var string[] Cache of properties that cannot be resolved. */
-    private array $m_unresolvedProperties = [];
+    private array $m_unresolvableProperties = [];
 
     /**
      * Initialise a new x-ray for an object.
@@ -65,10 +67,12 @@ class XRay
      */
     protected function resolveMethod(string $method): void
     {
-        if (in_array($method, $this->m_publicMethods) || in_array($method, $this->m_unresolvedMethods) || isset($this->m_xRayedMethods[$method])) {
+        if (in_array($method, $this->m_publicMethods) || in_array($method, $this->m_unresolvabledMethods) || isset($this->m_xRayedMethods[$method])) {
             return;
         }
 
+        // unlike properties, base methods show up on inheriting objects when reflected, so we don't need to travers the
+        // class hierarchy
         try {
             $reflector = $this->m_subjectReflector->getMethod($method);
         } catch (ReflectionException $err) {
@@ -76,7 +80,7 @@ class XRay
         }
 
         if (!isset($reflector) || $reflector->isStatic()) {
-            $this->m_unresolvedMethods[] = $method;
+            $this->m_unresolvabledMethods[] = $method;
             return;
         }
 
@@ -96,28 +100,33 @@ class XRay
      */
     protected function resolveProperty(string $property): void
     {
-        if (in_array($property, $this->m_publicProperties) || in_array($property, $this->m_unresolvedProperties) || isset($this->m_xRayedProperties[$property])) {
+        if (in_array($property, $this->m_publicProperties) || in_array($property, $this->m_unresolvableProperties) || isset($this->m_xRayedProperties[$property])) {
             return;
         }
 
-        try {
-            $reflector = $this->m_subjectReflector->getProperty($property);
-        } catch (ReflectionException $err) {
-            $reflector = null;
+        $classReflector = $this->m_subjectReflector;
+        $propertyReflector = null;
+
+        while ($classReflector && !$propertyReflector) {
+            if ($classReflector->hasProperty($property)) {
+                $propertyReflector = $classReflector->getProperty($property);
+            } else {
+                $classReflector = $classReflector->getParentClass();
+            }
         }
 
-        if (!isset($reflector) || $reflector->isStatic()) {
-            $this->m_unresolvedProperties[] = $property;
+        if (!isset($propertyReflector) || $propertyReflector->isStatic()) {
+            $this->m_unresolvableProperties[] = $property;
             return;
         }
 
-        if ($reflector->isPublic()) {
+        if ($propertyReflector->isPublic()) {
             $this->m_publicProperties[] = $property;
             return;
         }
 
-        $reflector->setAccessible(true);
-        $this->m_xRayedProperties[$property] = $reflector;
+        $propertyReflector->setAccessible(true);
+        $this->m_xRayedProperties[$property] = $propertyReflector;
     }
 
     /**
@@ -205,13 +214,13 @@ class XRay
             try {
                 return $this->m_xRayedMethods[$method]->invoke($this->subject(), ...$args);
             } catch (ReflectionException $err) {
-                throw new BadMethodCallException("Method '{$method}' could not be invoked on instance of class '{$this->className()}'.", 0, $err);
+                throw new BadMethodCallException("Method \"{$method}\" could not be invoked on instance of class \"{$this->m_subjectReflector->getName()}\"", 0, $err);
             }
         } elseif (method_exists($this->m_subject, "__call")) {
             return $this->m_subject->__call($method, $args);
         }
 
-        throw new BadMethodCallException("Method '{$method}' does not exist on object of class '{$this->m_subjectReflector->getName()}'.");
+        throw new BadMethodCallException("Method \"{$method}\" does not exist on object of class \"{$this->m_subjectReflector->getName()}\"");
     }
 
     /**
@@ -232,7 +241,7 @@ class XRay
             return $this->m_subject->__get($property);
         }
 
-        throw new LogicException("Property '{$property}' does not exist on object of class '{$this->m_subjectReflector->getName()}'.");
+        throw new LogicException("Property \"{$property}\" does not exist on object of class \"{$this->m_subjectReflector->getName()}\"");
     }
 
     /**
@@ -256,6 +265,6 @@ class XRay
             return;
         }
 
-        throw new LogicException("Property '{$property}' does not exist on object of class '{$this->m_subjectReflector->getName()}'.");
+        throw new LogicException("Property \"{$property}\" does not exist on object of class \"{$this->m_subjectReflector->getName()}\"");
     }
 }

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -4,8 +4,8 @@ namespace BeadTests\Core;
 
 use Bead\Core\Application;
 use Bead\Exceptions\ServiceAlreadyBoundException;
+use Bead\Testing\XRay;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
 
 use function is_array;
 
@@ -147,9 +147,8 @@ class ApplicationTest extends TestCase
      */
     public function testConfig1(string $key, mixed $default, mixed $expected): void
     {
-        $config = new ReflectionProperty(Application::class, "m_config");
-        $config->setAccessible(true);
-        $config->setValue($this->m_app, self::TestConfig);
+        $xRay = new XRay($this->m_app);
+        $xRay->m_config = self::TestConfig;
 
         if (null === $default) {
             $actual = $this->m_app->config($key);

--- a/test/Core/Binders/LoggerTest.php
+++ b/test/Core/Binders/LoggerTest.php
@@ -16,7 +16,6 @@ use Bead\Testing\XRay;
 use BeadTests\Framework\TestCase;
 use Mockery;
 use Mockery\MockInterface;
-use ReflectionClassConstant;
 
 /** Test the bundled logger binder. */
 final class LoggerTest extends TestCase

--- a/test/Core/ConsoleApplicationTest.php
+++ b/test/Core/ConsoleApplicationTest.php
@@ -95,13 +95,9 @@ final class ConsoleApplicationTest extends TestCase
                 $this->addFlag("help", "h", "Show the command's help message.", false);
                 $this->addFlag("debug", null, "Run the command in debug mode.", false);
 
-                $reflector = new ReflectionProperty(ConsoleApplication::class, "m_cmd");
-                $reflector->setAccessible(true);
-                $reflector->setValue($this, array_shift($args) ?? "");
-
-                $reflector = new ReflectionProperty(ConsoleApplication::class, "m_args");
-                $reflector->setAccessible(true);
-                $reflector->setValue($this, $args);
+                $xRay = new XRay($this);
+                $xRay->m_cmd = array_shift($args) ?? "";
+                $xRay->m_args = $args;
 
                 $this->m_configure = $configure->bindTo($this, $this);
                 $this->m_run = $run->bindTo($this, $this);

--- a/test/Core/ConsoleApplicationTest.php
+++ b/test/Core/ConsoleApplicationTest.php
@@ -14,7 +14,6 @@ use Closure;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClassConstant;
-use ReflectionProperty;
 use RuntimeException;
 use StdClass;
 

--- a/test/Database/ModelTest.php
+++ b/test/Database/ModelTest.php
@@ -2,6 +2,7 @@
 
 namespace BeadTests\Database;
 
+use Bead\Testing\XRay;
 use BeadTests\Framework\CallTracker;
 use BeadTests\Framework\TestCase;
 use DateTime;
@@ -401,11 +402,10 @@ class ModelTest extends TestCase
             $this->expectException($exceptionClass);
         }
 
-        $modelData = new ReflectionProperty(Model::class, "data");
-        $modelData->setAccessible(true);
+        $modelXray = new XRay($model);
 
         $model->foo_bar = $value;
-        $actual = $modelData->getValue($model)["foo_bar"];
+        $actual = $modelXray->data["foo_bar"];
         self::assertIsString($actual, "Value of foo_bar property expected to be string.");
         self::assertEquals($expected, $actual, "Value of foo_bar does not match expected.");
         self::assertEquals(1, $callTracker->callCount(), "Custom mutator was not called the correct number of times.");

--- a/test/Database/ModelTest.php
+++ b/test/Database/ModelTest.php
@@ -10,7 +10,6 @@ use Bead\Database\Model;
 use Bead\Exceptions\Database\ModelPropertyCastException;
 use LogicException;
 use PDO;
-use ReflectionProperty;
 use TypeError;
 
 use function Bead\Helpers\Iterable\all;

--- a/test/Framework/Constraints/AttributeIsInt.php
+++ b/test/Framework/Constraints/AttributeIsInt.php
@@ -2,10 +2,9 @@
 
 namespace BeadTests\Framework\Constraints;
 
+use Bead\Testing\XRay;
 use InvalidArgumentException;
 use PHPUnit\Framework\Constraint\Constraint;
-use ReflectionException;
-use ReflectionProperty;
 
 class AttributeIsInt extends Constraint
 {
@@ -33,14 +32,8 @@ class AttributeIsInt extends Constraint
             throw new InvalidArgumentException("cannot test for an empty attribute name");
         }
 
-        try {
-            $refAttr = new ReflectionProperty($object, $attr);
-        } catch (ReflectionException $err) {
-            throw new InvalidArgumentException("the property {$attr} does not exist in class " . get_class($object), 0, $err);
-        }
-
-        $refAttr->setAccessible(true);
-        return is_int($refAttr->getValue($object));
+        $xray = new XRay($object);
+        return is_int($xray->$attr);
     }
 
     /**

--- a/test/Session/SessionTest.php
+++ b/test/Session/SessionTest.php
@@ -19,7 +19,6 @@ use BeadTests\Framework\TestCase;
 use InvalidArgumentException;
 use Mockery;
 use Mockery\MockInterface;
-use ReflectionProperty;
 use RuntimeException;
 
 final class SessionTest extends TestCase

--- a/test/Testing/TestBaseClass.php
+++ b/test/Testing/TestBaseClass.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace BeadTests\Testing;

--- a/test/Testing/TestBaseClass.php
+++ b/test/Testing/TestBaseClass.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace BeadTests\Testing;
+
+use BadMethodCallException;
+use BeadTests\Framework\CallTracker;
+use BeadTests\Framework\TestCase;
+use LogicException;
+
+/**
+ * Test base class for (Static)XRay tests to ensure they can access base class properties and methods.
+ */
+class TestBaseClass
+{
+    public const BaseStringArg = "base-method-arg";
+
+    public const BaseIntArg = 99;
+
+    private static CallTracker $m_baseCallTracker;
+
+    private static string $m_basePrivateStaticProperty = "base-private-static-property";
+
+    public static string $basePublicStaticProperty = "base-public-static-property";
+
+    private string $m_basePrivateProperty = "base-private-property";
+
+    public string $basePublicProperty = "base-public-property";
+
+    private array $m_baseMagicProperties = [
+        "m_baseMagicProperty" => "base-magic-property",
+    ];
+
+    public function __construct(CallTracker $baseTracker)
+    {
+        self::$m_baseCallTracker = $baseTracker;
+    }
+
+    private static function basePrivateStaticMethod(): string
+    {
+        TestCase::fail("basePrivateStaticMethod() should not be called.");
+    }
+
+    public static function basePublicStaticMethod(): string
+    {
+        TestCase::fail("basePublicStaticMethod() should not be called.");
+    }
+
+    private static function basePrivateStaticMethodWithArgs(string $arg1, int $arg2): string
+    {
+        TestCase::fail("basePrivateStaticMethodWithArgs() should not be called.");
+    }
+
+    public static function basePublicStaticMethodWithArgs(string $arg1, int $arg2): string
+    {
+        TestCase::fail("basePublicStaticMethodWithArgs() should not be called.");
+    }
+
+    public function basePublicMethod(): string
+    {
+        self::$m_baseCallTracker->increment();
+        return "base-public-method";
+    }
+
+    public function basePublicMethodWithArgs(string $arg1, int $arg2): string
+    {
+        self::$m_baseCallTracker->increment();
+        TestCase::assertEquals(self::BaseStringArg, $arg1);
+        XRayTest::assertEquals(self::BaseIntArg, $arg2);
+        return "{$arg1} {$arg2}";
+    }
+
+    private function basePrivateMethod(): string
+    {
+        self::$m_baseCallTracker->increment();
+        return "base-private-method";
+    }
+
+    private function basePrivateMethodWithArgs(string $arg1, int $arg2): string
+    {
+        self::$m_baseCallTracker->increment();
+        TestCase::assertEquals(self::BaseStringArg, $arg1);
+        XRayTest::assertEquals(self::BaseIntArg, $arg2);
+        return "private {$arg1} {$arg2}";
+    }
+
+    public function __get(string $property): string
+    {
+        if ("m_baseMagicProperty" === $property) {
+            return $this->m_baseMagicProperties[$property];
+        }
+
+        throw new LogicException("Property {$property} does not exist.");
+    }
+
+    public function __set(string $property, string $value): void
+    {
+        if ("m_baseMagicProperty" === $property) {
+            $this->m_baseMagicProperties[$property] = $value;
+            return;
+        }
+
+        throw new LogicException("Property {$property} does not exist.");
+    }
+
+    public function __call(string $method, array $args): string
+    {
+        if ("baseMagicMethod" === $method) {
+            self::$m_baseCallTracker->increment();
+            return "base-magic-method";
+        }
+
+        if ("baseMagicMethodWithArgs" === $method) {
+            self::$m_baseCallTracker->increment();
+            return "{$args[0]} {$args[1]}";
+        }
+
+        throw new BadMethodCallException("Non-existent magic method.");
+    }
+
+    public static function __callStatic(string $method, array $args): void
+    {
+        TestCase::fail("__callStatic() should not be called.");
+    }
+}

--- a/test/Testing/XRayTest.php
+++ b/test/Testing/XRayTest.php
@@ -284,7 +284,9 @@ class XRayTest extends TestCase
     public function testNonExistentProperty(): void
     {
         // have to test on class with no magic __get(), otherwise __get() will be called with the property name
-        $object = new class{};
+        $object = new class {
+        };
+
         $xRay = new XRay($object);
         $className = $object::class;
         self::expectException(LogicException::class);
@@ -298,7 +300,9 @@ class XRayTest extends TestCase
     public function testSetNonExistentProperty(): void
     {
         // have to test on class with no magic __get(), otherwise __get() will be called with the property name
-        $object = new class{};
+        $object = new class {
+        };
+
         $xRay = new XRay($object);
         $className = $object::class;
         self::expectException(LogicException::class);
@@ -553,7 +557,9 @@ class XRayTest extends TestCase
     public function testNonExistentMethod(): void
     {
         // have to test on class with no magic __call(), otherwise __call() will be called with the method name
-        $object = new class {};
+        $object = new class {
+        };
+
         $className = $object::class;
         $xRay = new XRay($object);
         self::expectException(BadMethodCallException::class);

--- a/test/Testing/XRayTest.php
+++ b/test/Testing/XRayTest.php
@@ -7,20 +7,26 @@ use BeadTests\Framework\CallTracker;
 use BeadTests\Framework\TestCase;
 use Bead\Testing\XRay;
 use LogicException;
+use ReflectionException;
 
 class XRayTest extends TestCase
 {
     public const StringArg = "hitch-hiker";
+
     public const IntArg = 42;
 
     private XRay $m_xRay;
+
     private CallTracker $m_tracker;
+
+    private CallTracker $m_baseTracker;
 
     public function setUp(): void
     {
         $this->m_tracker = new CallTracker();
+        $this->m_baseTracker = new CallTracker();
 
-        $testObject = new class ($this->m_tracker)
+        $testObject = new class ($this->m_tracker, $this->m_baseTracker) extends TestBaseClass
         {
             private static CallTracker $m_tracker;
             private static string $m_privateStaticProperty = "private-static-property";
@@ -33,8 +39,9 @@ class XRayTest extends TestCase
                 "m_magicProperty" => "magic-property",
             ];
 
-            public function __construct(CallTracker $tracker)
+            public function __construct(CallTracker $tracker, CallTracker $baseTracker)
             {
+                parent::__construct($baseTracker);
                 self::$m_tracker = $tracker;
             }
 
@@ -92,7 +99,7 @@ class XRayTest extends TestCase
                     return $this->m_magicProperties[$property];
                 }
 
-                throw new LogicException("Property {$property} does not exist.");
+                return parent::__get($property);
             }
 
             public function __set(string $property, string $value): void
@@ -102,7 +109,7 @@ class XRayTest extends TestCase
                     return;
                 }
 
-                throw new LogicException("Property {$property} does not exist.");
+                parent::__set($property, $value);
             }
 
             public function __call(string $method, array $args): string
@@ -117,7 +124,7 @@ class XRayTest extends TestCase
                     return "{$args[0]} {$args[1]}";
                 }
 
-                throw new BadMethodCallException("Non-existent magic method.");
+                return parent::__call($method, $args);
             }
 
             public static function __callStatic(string $method, array $args): void
@@ -129,6 +136,7 @@ class XRayTest extends TestCase
         $this->m_xRay = new XRay($testObject);
     }
 
+    /** Ensure we can access a public property defined on the class itself. */
     public function testPublicProperty(): void
     {
         self::assertTrue($this->m_xRay->isPublicProperty("publicProperty"));
@@ -136,6 +144,15 @@ class XRayTest extends TestCase
         self::assertEquals("public-property", $this->m_xRay->publicProperty);
     }
 
+    /** Ensure we can access a public property on a base class. */
+    public function testBasePublicProperty(): void
+    {
+        self::assertTrue($this->m_xRay->isPublicProperty("basePublicProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("basePublicProperty"));
+        self::assertEquals("base-public-property", $this->m_xRay->basePublicProperty);
+    }
+
+    /** Ensure we can set a public property defined on the class itself. */
     public function testSetPublicProperty(): void
     {
         self::assertTrue($this->m_xRay->isPublicProperty("publicProperty"));
@@ -145,6 +162,17 @@ class XRayTest extends TestCase
         self::assertEquals(self::StringArg, $this->m_xRay->publicProperty);
     }
 
+    /** Ensure we can set a public property on a base class. */
+    public function testSetBasePublicProperty(): void
+    {
+        self::assertTrue($this->m_xRay->isPublicProperty("basePublicProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("basePublicProperty"));
+        self::assertEquals("base-public-property", $this->m_xRay->basePublicProperty);
+        $this->m_xRay->basePublicProperty = self::StringArg;
+        self::assertEquals(self::StringArg, $this->m_xRay->basePublicProperty);
+    }
+
+    /** Ensure we can access a private property defined on the class itself. */
     public function testXRayedProperty(): void
     {
         self::assertFalse($this->m_xRay->isPublicProperty("m_privateProperty"));
@@ -152,6 +180,15 @@ class XRayTest extends TestCase
         self::assertEquals("private-property", $this->m_xRay->m_privateProperty);
     }
 
+    /** Ensure we can access a private property on a base class. */
+    public function testXRayedBaseProperty(): void
+    {
+        self::assertFalse($this->m_xRay->isPublicProperty("m_basePrivateProperty"));
+        self::assertTrue($this->m_xRay->isXRayedProperty("m_basePrivateProperty"));
+        self::assertEquals("base-private-property", $this->m_xRay->m_basePrivateProperty);
+    }
+
+    /** Ensure we can set a private property defined on the class itself. */
     public function testSetXRayedProperty(): void
     {
         self::assertFalse($this->m_xRay->isPublicProperty("m_privateProperty"));
@@ -161,6 +198,17 @@ class XRayTest extends TestCase
         self::assertEquals(self::StringArg, $this->m_xRay->m_privateProperty);
     }
 
+    /** Ensure we can set a private property on a base class. */
+    public function testSetXRayedBaseProperty(): void
+    {
+        self::assertFalse($this->m_xRay->isPublicProperty("m_basePrivateProperty"));
+        self::assertTrue($this->m_xRay->isXRayedProperty("m_basePrivateProperty"));
+        self::assertEquals("base-private-property", $this->m_xRay->m_basePrivateProperty);
+        $this->m_xRay->m_basePrivateProperty = self::StringArg;
+        self::assertEquals(self::StringArg, $this->m_xRay->m_basePrivateProperty);
+    }
+
+    /** Ensure we can access a magic property on the class itself. */
     public function testMagicProperty(): void
     {
         self::assertFalse($this->m_xRay->isPublicProperty("m_magicProperty"));
@@ -168,6 +216,15 @@ class XRayTest extends TestCase
         self::assertEquals("magic-property", $this->m_xRay->m_magicProperty);
     }
 
+    /** Ensure we can access a magic property on a base class. */
+    public function testBaseMagicProperty(): void
+    {
+        self::assertFalse($this->m_xRay->isPublicProperty("m_baseMagicProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("m_baseMagicProperty"));
+        self::assertEquals("base-magic-property", $this->m_xRay->m_baseMagicProperty);
+    }
+
+    /** Ensure we can set a magic property on the class itself. */
     public function testSetMagicProperty(): void
     {
         self::assertFalse($this->m_xRay->isPublicProperty("m_magicProperty"));
@@ -177,6 +234,17 @@ class XRayTest extends TestCase
         self::assertEquals(self::StringArg, $this->m_xRay->m_magicProperty);
     }
 
+    /** Ensure we can set a magic property on a base class. */
+    public function testSetBaseMagicProperty(): void
+    {
+        self::assertFalse($this->m_xRay->isPublicProperty("m_baseMagicProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("m_baseMagicProperty"));
+        self::assertEquals("base-magic-property", $this->m_xRay->m_baseMagicProperty);
+        $this->m_xRay->m_baseMagicProperty = self::StringArg;
+        self::assertEquals(self::StringArg, $this->m_xRay->m_baseMagicProperty);
+    }
+
+    /** Ensure public static properties defined on the class itself aren't accessible. */
     public function testPublicStaticProperty(): void
     {
         self::expectException(LogicException::class);
@@ -185,6 +253,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->publicStaticProperty);
     }
 
+    /** Ensure public static properties on a base class aren't accessible. */
+    public function testBasePublicStaticProperty(): void
+    {
+        self::expectException(LogicException::class);
+        self::assertFalse($this->m_xRay->isPublicProperty("basePublicStaticProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("basePublicStaticProperty"));
+        self::assertEquals("", $this->m_xRay->publicStaticProperty);
+    }
+
+    /** Ensure private static properties defined on the class itself aren't accessible. */
     public function testPrivateStaticProperty(): void
     {
         self::expectException(LogicException::class);
@@ -193,14 +271,44 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->m_privateStaticProperty);
     }
 
-    public function testNonExistentProperty(): void
+    /** Ensure private static properties on a base class aren't accessible. */
+    public function testBasePrivateStaticProperty(): void
     {
         self::expectException(LogicException::class);
-        self::assertFalse($this->m_xRay->isPublicProperty("nonExistentProperty"));
-        self::assertFalse($this->m_xRay->isXRayedProperty("nonExistentProperty"));
-        self::assertEquals("", $this->m_xRay->nonExistentProperty);
+        self::assertFalse($this->m_xRay->isPublicProperty("m_basePrivateStaticProperty"));
+        self::assertFalse($this->m_xRay->isXRayedProperty("m_basePrivateStaticProperty"));
+        self::assertEquals("", $this->m_xRay->m_basePrivateStaticProperty);
     }
 
+    /** Ensure non-existent properties error. */
+    public function testNonExistentProperty(): void
+    {
+        // have to test on class with no magic __get(), otherwise __get() will be called with the property name
+        $object = new class{};
+        $xRay = new XRay($object);
+        $className = $object::class;
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage("Property \"nonExistentProperty\" does not exist on object of class \"{$className}\"");
+        self::assertFalse($xRay->isPublicProperty("nonExistentProperty"));
+        self::assertFalse($xRay->isXRayedProperty("nonExistentProperty"));
+        $ignored = $xRay->nonExistentProperty;
+    }
+
+    /** Ensure non-existent properties error. */
+    public function testSetNonExistentProperty(): void
+    {
+        // have to test on class with no magic __get(), otherwise __get() will be called with the property name
+        $object = new class{};
+        $xRay = new XRay($object);
+        $className = $object::class;
+        self::expectException(LogicException::class);
+        self::expectExceptionMessage("Property \"nonExistentProperty\" does not exist on object of class \"{$className}\"");
+        self::assertFalse($xRay->isPublicProperty("nonExistentProperty"));
+        self::assertFalse($xRay->isXRayedProperty("nonExistentProperty"));
+        $xRay->nonExistentProperty = "should-not-get-this";
+    }
+
+    /** Ensure empty property names error. */
     public function testEmptyProperty(): void
     {
         self::expectException(LogicException::class);
@@ -209,6 +317,7 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->{""});
     }
 
+    /** Ensure we can call a public method defined on the class itself. */
     public function testPublicMethod(): void
     {
         $this->m_tracker->reset();
@@ -218,6 +327,17 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a public method inherited from a base class. */
+    public function testBasePublicMethod(): void
+    {
+        $this->m_baseTracker->reset();
+        self::assertTrue($this->m_xRay->isPublicMethod("basePublicMethod"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePublicMethod"));
+        self::assertEquals("base-public-method", $this->m_xRay->basePublicMethod());
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can call a public method defined on the class itself with arguments. */
     public function testPublicMethodWithArgs(): void
     {
         self::assertTrue($this->m_xRay->isPublicMethod("publicMethodWithArgs"));
@@ -228,6 +348,18 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a public method with arguments inherited from a base class. */
+    public function testBasePublicMethodWithArgs(): void
+    {
+        self::assertTrue($this->m_xRay->isPublicMethod("basePublicMethodWithArgs"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePublicMethodWithArgs"));
+        $this->m_baseTracker->reset();
+        $expected = TestBaseClass::BaseStringArg . " " . TestBaseClass::BaseIntArg;
+        self::assertEquals($expected, $this->m_xRay->basePublicMethodWithArgs(TestBaseClass::BaseStringArg, TestBaseClass::BaseIntArg));
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can call a private method on the class itself. */
     public function testXRayedMethod(): void
     {
         $this->m_tracker->reset();
@@ -237,6 +369,17 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a private method inherited from a base class. */
+    public function testXRayedBaseMethod(): void
+    {
+        $this->m_baseTracker->reset();
+        self::assertFalse($this->m_xRay->isPublicMethod("basePrivateMethod"));
+        self::assertTrue($this->m_xRay->isXRayedMethod("basePrivateMethod"));
+        self::assertEquals("base-private-method", $this->m_xRay->basePrivateMethod());
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can call a private method defined on the class itself with arguments. */
     public function testXRayedMethodWithArgs(): void
     {
         self::assertFalse($this->m_xRay->isPublicMethod("privateMethodWithArgs"));
@@ -247,6 +390,18 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a private method with arguments inherited from a base class. */
+    public function testXRayedBaseMethodWithArgs(): void
+    {
+        self::assertFalse($this->m_xRay->isPublicMethod("basePrivateMethodWithArgs"));
+        self::assertTrue($this->m_xRay->isXRayedMethod("basePrivateMethodWithArgs"));
+        $this->m_baseTracker->reset();
+        $expected = "private " . TestBaseClass::BaseStringArg . " " . TestBaseClass::BaseIntArg;
+        self::assertEquals($expected, $this->m_xRay->basePrivateMethodWithArgs(TestBaseClass::BaseStringArg, TestBaseClass::BaseIntArg));
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can call a magic method on the class itself. */
     public function testMagicMethod(): void
     {
         $this->m_tracker->reset();
@@ -256,6 +411,17 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a magic method inherited from a base class. */
+    public function testBaseMagicMethod(): void
+    {
+        $this->m_baseTracker->reset();
+        self::assertFalse($this->m_xRay->isPublicMethod("baseMagicMethod"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("baseMagicMethod"));
+        self::assertEquals("base-magic-method", $this->m_xRay->baseMagicMethod());
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can call a magic method defined on the class itself with arguments. */
     public function testMagicMethodWithArgs(): void
     {
         $this->m_tracker->reset();
@@ -265,6 +431,17 @@ class XRayTest extends TestCase
         self::assertEquals(1, $this->m_tracker->callCount());
     }
 
+    /** Ensure we can call a magic method with arguments inherited from a base class. */
+    public function testBaseMagicMethodWithArgs(): void
+    {
+        $this->m_baseTracker->reset();
+        self::assertFalse($this->m_xRay->isPublicMethod("baseMagicMethodWithArgs"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("baseMagicMethodWithArgs"));
+        self::assertEquals(TestBaseClass::BaseStringArg . " " . TestBaseClass::BaseIntArg, $this->m_xRay->baseMagicMethodWithArgs(TestBaseClass::BaseStringArg, TestBaseClass::BaseIntArg));
+        self::assertEquals(1, $this->m_baseTracker->callCount());
+    }
+
+    /** Ensure we can't call a public static method defined on the class itself. */
     public function testPublicStaticMethod(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -273,6 +450,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->publicStaticMethod());
     }
 
+    /** Ensure we can't call a public static method from a base class. */
+    public function testBasePublicStaticMethod(): void
+    {
+        self::expectException(BadMethodCallException::class);
+        self::assertFalse($this->m_xRay->isPublicMethod("basePublicStaticMethod"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePublicStaticMethod"));
+        self::assertEquals("", $this->m_xRay->basePublicStaticMethod());
+    }
+
+    /** Ensure we can't call a public static method defined on the class itself with arguments. */
     public function testPublicStaticMethodWithArgs(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -281,6 +468,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->publicStaticMethodWithArgs(self::StringArg, self::IntArg));
     }
 
+    /** Ensure we can't call a public static method with arguments from a base class. */
+    public function testBasePublicStaticMethodWithArgs(): void
+    {
+        self::expectException(BadMethodCallException::class);
+        self::assertFalse($this->m_xRay->isPublicMethod("basePublicStaticMethodWithArgs"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePublicStaticMethodWithArgs"));
+        self::assertEquals("", $this->m_xRay->basePublicStaticMethodWithArgs(TestBaseClass::BaseStringArg, TestBaseClass::BaseIntArg));
+    }
+
+    /** Ensure we can't call a private static method defined on the class itself. */
     public function testPrivateStaticMethod(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -289,6 +486,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->privateStaticMethod());
     }
 
+    /** Ensure we can't call a private static method from a base class. */
+    public function testBasePrivateStaticMethod(): void
+    {
+        self::expectException(BadMethodCallException::class);
+        self::assertFalse($this->m_xRay->isPublicMethod("basePrivateStaticMethod"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePrivateStaticMethod"));
+        self::assertEquals("", $this->m_xRay->basePrivateStaticMethod());
+    }
+
+    /** Ensure we can't call a private static method defined on the class itself with arguments. */
     public function testPrivateStaticMethodWithArgs(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -297,6 +504,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->privateStaticMethodWithArgs());
     }
 
+    /** Ensure we can't call a private static method with arguments from a base class. */
+    public function testBasePrivateStaticMethodWithArgs(): void
+    {
+        self::expectException(BadMethodCallException::class);
+        self::assertFalse($this->m_xRay->isPublicMethod("basePrivateStaticMethodWithArgs"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("basePrivateStaticMethodWithArgs"));
+        self::assertEquals("", $this->m_xRay->basePrivateStaticMethodWithArgs());
+    }
+
+    /** Ensure we can't call a maagic static method odefined n the class itself. */
     public function testStaticMagicMethod(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -305,6 +522,16 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->staticMagicMethod());
     }
 
+    /** Ensure we can't call a magic static method from a base class. */
+    public function testBaseStaticMagicMethod(): void
+    {
+        self::expectException(BadMethodCallException::class);
+        self::assertFalse($this->m_xRay->isPublicMethod("baseStaticMagicMethod"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("baseStaticMagicMethod"));
+        self::assertEquals("", $this->m_xRay->baseStaticMagicMethod());
+    }
+
+    /** Ensure we can't call a magic static method defined on the class itself with arguments. */
     public function testStaticMagicMethodWithArgs(): void
     {
         self::expectException(BadMethodCallException::class);
@@ -313,14 +540,50 @@ class XRayTest extends TestCase
         self::assertEquals("", $this->m_xRay->staticMagicMethodWithArgs(self::StringArg, self::IntArg));
     }
 
-    public function testNonExistentMethod(): void
+    /** Ensure we can't call a magic static method with arguments from a base class. */
+    public function testBaseStaticMagicMethodWithArgs(): void
     {
         self::expectException(BadMethodCallException::class);
-        self::assertFalse($this->m_xRay->isPublicMethod("nonExistentMethod"));
-        self::assertFalse($this->m_xRay->isXRayedMethod("nonExistentMethod"));
-        self::assertEquals("", $this->m_xRay->nonExistentMethod());
+        self::assertFalse($this->m_xRay->isPublicMethod("baseStaticMagicMethodWithArgs"));
+        self::assertFalse($this->m_xRay->isXRayedMethod("baseStaticMagicMethodWithArgs"));
+        self::assertEquals("", $this->m_xRay->baseStaticMagicMethodWithArgs(self::StringArg, self::IntArg));
     }
 
+    /** Ensure we can't call methods that don't exist. */
+    public function testNonExistentMethod(): void
+    {
+        // have to test on class with no magic __call(), otherwise __call() will be called with the method name
+        $object = new class {};
+        $className = $object::class;
+        $xRay = new XRay($object);
+        self::expectException(BadMethodCallException::class);
+        self::expectExceptionMessage("Method \"nonExistentMethod\" does not exist on object of class \"{$className}\"");
+        self::assertFalse($xRay->isPublicMethod("nonExistentMethod"));
+        self::assertFalse($xRay->isXRayedMethod("nonExistentMethod"));
+        $xRay->nonExistentMethod();
+    }
+
+    /** Ensure we get a BadMethodCall excception when invoke() throws a ReflectionException. */
+    public function testInvokeThrows(): void
+    {
+        $object = new class {
+            private function mockInvokeThrowsReflectionException(): void
+            {
+                throw new ReflectionException("");
+            }
+        };
+
+        $className = $object::class;
+        $xRay = new XRay($object);
+
+        self::expectException(BadMethodCallException::class);
+        self::expectExceptionMessage("Method \"mockInvokeThrowsReflectionException\" could not be invoked on instance of class \"{$className}\"");
+        self::assertFalse($xRay->isPublicMethod("mockInvokeThrowsReflectionException"));
+        self::assertTrue($xRay->isXRayedMethod("mockInvokeThrowsReflectionException"));
+        $xRay->mockInvokeThrowsReflectionException();
+    }
+
+    /** Ensure we can't call methods with an empty name. */
     public function testEmptyMethod(): void
     {
         self::expectException(BadMethodCallException::class);

--- a/test/Util/ProcessTest.php
+++ b/test/Util/ProcessTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BeadTests\Util;
 
+use Bead\Testing\XRay;
 use InvalidArgumentException;
 use TypeError;
 use Bead\Process;
@@ -331,17 +332,14 @@ class ProcessTest extends TestCase
         }
 
         $process = new Process($command, $arguments, $workingDirectory, $outputNotifier, $errorNotifier);
+        $processXray = new XRay($process);
+
         self::assertEquals($command, $process->command(), "Process was not constructed with correct command.");
         self::assertEquals($arguments, $process->arguments(), "Process was not constructed with correct arguments.");
         self::assertEquals($workingDirectory ?? getcwd(), $process->workingDirectory(), "Process was not constructed with correct working directory.");
 
-        $property = new \ReflectionProperty($process, "m_outputNotifier");
-        $property->setAccessible(true);
-        self::assertEquals($outputNotifier, $property->getValue($process), "Output notifier was not set correctly by constructor.");
-
-        $property = new \ReflectionProperty($process, "m_errorNotifier");
-        $property->setAccessible(true);
-        self::assertEquals($errorNotifier, $property->getValue($process), "Error notifier was not set correctly by constructor.");
+        self::assertEquals($outputNotifier, $processXray->m_outputNotifier, "Output notifier was not set correctly by constructor.");
+        self::assertEquals($errorNotifier, $processXray->m_errorNotifier, "Error notifier was not set correctly by constructor.");
     }
 
     /**

--- a/test/Util/ScopeGuardTest.php
+++ b/test/Util/ScopeGuardTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BeadTests\Util;
 
+use Bead\Testing\XRay;
 use Bead\Util\ScopeGuard;
 use TypeError;
 
@@ -224,9 +225,10 @@ class ScopeGuardTest extends \BeadTests\Framework\TestCase
         );
 
         $guard->addClosure($closure);
-        $closuresMethod = new \ReflectionMethod($guard, "closures");
-        $closuresMethod->setAccessible(true);
-        self::assertEquals(2, count($closuresMethod->invoke($guard)), "Scope guard did not have two closures after call to addClosure().");
+        $guardXRay = new XRay($guard);
+//        $closuresMethod = new \ReflectionMethod($guard, "closures");
+//        $closuresMethod->setAccessible(true);
+        self::assertCount(2, $guardXRay->closures(), "Scope guard did not have two closures after call to addClosure().");
     }
 
     /**

--- a/test/Util/StopwatchTest.php
+++ b/test/Util/StopwatchTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace BeadTests\Util;
 
+use Bead\Testing\XRay;
 use Bead\Util\Stopwatch;
 use BeadTests\Framework\TestCase;
 use Generator;
 use LogicException;
-use ReflectionProperty;
 use TypeError;
 
 /**
@@ -338,9 +338,8 @@ class StopwatchTest extends TestCase
     public function testAddListener($event, $listener): void
     {
         $this->testStopwatch->addListener($event, $listener);
-        $listenersProperty = new ReflectionProperty(Stopwatch::class, "m_listeners");
-        $listenersProperty->setAccessible(true);
-        self::assertEquals($listenersProperty->getValue($this->testStopwatch)[$event][0], $listener, "The array of listeners for event {$event} did not consist of the test listener.");
+        $xRay = new XRay($this->testStopwatch);
+        self::assertEquals($listener, $xRay->m_listeners[$event][0], "The array of listeners for event {$event} did not consist of the test listener.");
     }
 
     /** Ensure addListener() rejects invalid events. */

--- a/test/Web/ApplicationTest.php
+++ b/test/Web/ApplicationTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace BeadTests\Web;
 
 use Bead\Facades\Session;
+use Bead\Testing\StaticXRay;
 use Bead\Testing\XRay;
+use Bead\Core\Application as CoreApplication;
 use Bead\Web\Application as WebApplication;
 use BeadTests\Framework\TestCase;
-use ReflectionProperty;
 
 class ApplicationTest extends TestCase
 {
@@ -20,13 +21,11 @@ class ApplicationTest extends TestCase
 
     public function tearDown(): void
     {
-        $instance = new ReflectionProperty(WebApplication::class, "s_instance");
-        $instance->setAccessible(true);
-        $instance->setValue(null);
+        $xRay = new StaticXRay(CoreApplication::class);
+        $xRay->s_instance = null;
 
-        $session = new ReflectionProperty(Session::class, "session");
-        $session->setAccessible(true);
-        $session->setValue(null);
+        $xRay = new StaticXRay(Session::class);
+        $xRay->session = null;
 
         parent::tearDown();
     }

--- a/test/Web/RequestTest.php
+++ b/test/Web/RequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BeadTests\Web;
 
+use Bead\Testing\StaticXRay;
 use Bead\Web\Request;
 use BeadTests\Framework\TestCase;
 use InvalidArgumentException;
@@ -29,9 +30,8 @@ class RequestTest extends TestCase
     public function tearDown(): void
     {
         // ensure the request doesn't persist between tests.
-        $property = new ReflectionProperty(Request::class, "s_originalRequest");
-        $property->setAccessible(true);
-        $property->setValue(null);
+        $xRay = new StaticXRay(Request::class);
+        $xRay->s_originalRequest = null;
         unset($this->request);
     }
 

--- a/test/Web/RouterTest.php
+++ b/test/Web/RouterTest.php
@@ -25,7 +25,6 @@ use BeadTests\Framework\TestCase;
 use Closure;
 use InvalidArgumentException;
 use Mockery;
-use ReflectionProperty;
 
 use function array_unique;
 use function Bead\Helpers\Iterable\accumulate;
@@ -3740,19 +3739,19 @@ class RouterTest extends TestCase
         }
 
         $router = new Router();
-        /** @noinspection PhpUnhandledExceptionInspection Guaranteed not to throw with these arguments. */
-        $routeCollection = new ReflectionProperty($router, "m_routes");
-        $routeCollection->setAccessible(true);
+        $routerXRay = new XRay($router);
+
         /** @noinspection PhpUnhandledExceptionInspection Should never throw with test data. */
         $router->register($route1, $route1Methods, function () {
         });
 
         // fetch the route count so that we can assert that the registration of the second route adds to it if it
         // doesn't throw
-        $routeCount = accumulate($routeCollection->getValue($router), $accumulateRoutes);
+        $routeCount = accumulate($routerXRay->m_routes, $accumulateRoutes);
         /** @noinspection PhpUnhandledExceptionInspection Should only throw an expected test exception. */
         $router->register($route2, $route2Methods, function () {
         });
-        self::assertGreaterThan($routeCount, accumulate($routeCollection->getValue($router), $accumulateRoutes), "The registration of the second route succeeded but didn't add to the routes colleciton in the router.");
+
+        self::assertGreaterThan($routeCount, accumulate($routerXRay->m_routes, $accumulateRoutes), "The registration of the second route succeeded but didn't add to the routes colleciton in the router.");
     }
 }


### PR DESCRIPTION
Updated XRay to traverse the inheritance tree when looking for xrayed properties. Updated tests to use XRay and StaticXRay instead of Reflection.