### PR TITLE
BEAD-207 support feature flags read from the app config file

### DIFF
--- a/src/Contracts/FeatureFlag.php
+++ b/src/Contracts/FeatureFlag.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Contracts;
+
+/** Contract for classes representing feature flags. */
+interface FeatureFlag
+{
+    /** @return string The name of the feature. */
+    public function feature(): string;
+
+    /** @return string|null The feature's variant, if there are different implementations of the feature. */
+    public function variant(): ?string;
+}

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -381,7 +381,11 @@ abstract class Application implements ServiceContainer, ContainerInterface
         return $this->service($id);
     }
 
-    /** Internal helper to read the feature flags from the app config. */
+    /**
+     * Internal helper to read the feature flags from the app config.
+     *
+     * @throws InvalidConfigurationException
+     */
     protected function readFeatureFlags(): void
     {
         $featureFlags = $this->config("app.feature-flags");
@@ -412,6 +416,7 @@ abstract class Application implements ServiceContainer, ContainerInterface
      * Feature flags are loaded on-demand from the config the first time they are requested using this method.
      *
      * @return FeatureFlag[]
+     * @throws InvalidConfigurationException
      */
     public function featureFlags(): array
     {
@@ -431,6 +436,7 @@ abstract class Application implements ServiceContainer, ContainerInterface
      * Matching feature flag names is not case-sensitive.
      *
      * @param string $feature The feature to check for.
+     * @throws InvalidConfigurationException
      */
     public function hasFeatureFlag(string $feature): bool
     {
@@ -444,6 +450,7 @@ abstract class Application implements ServiceContainer, ContainerInterface
      *
      * @param string $feature The feature sought.
      * @return FeatureFlag|null The matching FeatureFlag, or null if the named feature is not flagged.
+     * @throws InvalidConfigurationException
      */
     public function featureFlag(string $feature): ?FeatureFlag
     {

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -8,6 +8,7 @@ use Bead\Contracts\ErrorHandler;
 use Bead\Contracts\ServiceContainer;
 use Bead\Contracts\Translator as TranslatorContract;
 use Bead\Core\ErrorHandler as BeadErrorHandler;
+use Bead\Core\FeatureFlag;
 use Bead\Database\Connection;
 use Bead\Environment\Environment;
 use Bead\Environment\Sources\Environment as EnvironmentSource;
@@ -65,6 +66,9 @@ abstract class Application implements ServiceContainer, ContainerInterface
 
     /** @var array The sesrvices bound to the container. */
     private array $m_services = [];
+
+    /** @var array|null Cache of the feature flags read from the config. */
+    private ?array $m_featureFlags = null;
 
     /**
      * @param string $appRoot
@@ -375,6 +379,83 @@ abstract class Application implements ServiceContainer, ContainerInterface
     public function get(string $id)
     {
         return $this->service($id);
+    }
+
+    /** Internal helper to read the feature flags from the app config. */
+    protected function readFeatureFlags(): void
+    {
+        $featureFlags = $this->config("app.feature-flags");
+
+        if (null === $featureFlags) {
+            $this->m_featureFlags = [];
+            return;
+        }
+
+        if (!is_array($featureFlags)) {
+            throw new InvalidConfigurationException("app.feature-flags", "Expecting array of feature flags, found " . gettype($featureFlags));
+        }
+
+        foreach ($featureFlags as $feature => $variant) {
+            if (!is_string($feature)) {
+                throw new InvalidConfigurationException("app.feature-flags", "Expecting string feature flag, found " . gettype($feature));
+            }
+
+            if (!is_string($variant) && null !== $variant) {
+                throw new InvalidConfigurationException("app.feature-flags", "Expecting string or null feature variant, found " . gettype($variant));
+            }
+
+            $this->m_featureFlags[] = new FeatureFlag($feature, $variant);
+        }
+    }
+
+    /**
+     * Feature flags are loaded on-demand from the config the first time they are requested using this method.
+     *
+     * @return FeatureFlag[]
+     */
+    public function featureFlags(): array
+    {
+        // we read on-demand so that binders have access to the feature flags - config is guaranteed by the base class
+        // to be loaded before binders, so if a binder calls this we know the config has been loaded and we can read the
+        // feature flags from it
+        if (null === $this->m_featureFlags) {
+            $this->readFeatureFlags();
+        }
+
+        return $this->m_featureFlags;
+    }
+
+    /**
+     * Check whether the application has a given feature flag.
+     *
+     * Matching feature flag names is not case-sensitive.
+     *
+     * @param string $feature The feature to check for.
+     */
+    public function hasFeatureFlag(string $feature): bool
+    {
+        return null !== $this->featureFlag($feature);
+    }
+
+    /**
+     * Fetch a named feature flag.
+     *
+     * Matching feature flag names is not case-sensitive.
+     *
+     * @param string $feature The feature sought.
+     * @return FeatureFlag|null The matching FeatureFlag, or null if the named feature is not flagged.
+     */
+    public function featureFlag(string $feature): ?FeatureFlag
+    {
+        $feature = mb_strtolower($feature);
+
+        foreach ($this->featureFlags() as $featureFlag) {
+            if (mb_strtolower($featureFlag->feature()) === $feature) {
+                return $featureFlag;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Core/FeatureFlag.php
+++ b/src/Core/FeatureFlag.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Core;
+
+use Bead\Contracts\FeatureFlag as FeatureFlagContract;
+
+/**
+ * Lightweight representation of a feature flag.
+ *
+ * Instances of this class model immutability.
+ */
+class FeatureFlag implements FeatureFlagContract
+{
+    /** @var string The name of the feature. */
+    private string $feature;
+
+    /** @var string|null The variant of the feature, if applicable. */
+    private ?string $variant;
+
+    /**
+     * @param string $feature The name of the feature.
+     * @param string|null $variant The variant, if applicable.
+     */
+    public function __construct(string $feature, ?string $variant = null)
+    {
+        $this->feature = $feature;
+        $this->variant = $variant;
+    }
+
+    /** @return string The feature name. */
+    public function feature(): string
+    {
+        return $this->feature;
+    }
+
+    /**
+     * Create a copy of the FeatureFlag with a different feature name.
+     *
+     * @param string $feature The name of the feature.
+     *
+     * @return self A clone of the FeatureFlag with the given name.
+     */
+    public function withFeature(string $feature): self
+    {
+        $clone = clone $this;
+        $clone->feature = $feature;
+        return $clone;
+    }
+
+    /** @return string|null The feature variant. */
+    public function variant(): ?string
+    {
+        return $this->variant;
+    }
+
+    /**
+     * Create a copy of the FeatureFlag with a different variant.
+     *
+     * @param string|null $variant The variant.
+     *
+     * @return self A clone of the FeatureFlag with the given variant.
+     */
+    public function withVariant(?string $variant): self
+    {
+        $clone = clone $this;
+        $clone->variant = $variant;
+        return $clone;
+    }
+}

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -2,8 +2,11 @@
 
 namespace BeadTests\Core;
 
+use Bead\Contracts\FeatureFlag as FeatureFlagContract;
 use Bead\Core\Application;
+use Bead\Core\FeatureFlag;
 use Bead\Exceptions\ServiceAlreadyBoundException;
+use Bead\Testing\XRay;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -12,6 +15,12 @@ use function is_array;
 class ApplicationTest extends TestCase
 {
     private const TestConfig = [
+        "app" => [
+            "feature-flags" => [
+                "feature-flag-1" => "variant-1",
+                "feature-flag-2" => null,
+            ],
+        ],
         "mail" => [
             "transport" => "mailgun",
             "transports" => [
@@ -162,5 +171,34 @@ class ApplicationTest extends TestCase
         } else {
             self::assertEquals($expected, $actual);
         }
+    }
+
+    /** Ensure feature flags are not read from config until required */
+    public function testReadFeatureFlags1()
+    {
+        self::assertNull((new XRay($this->m_app))->m_featureFlags);
+    }
+
+    /** Ensure feature flags are successfully read from the app config */
+    public function testReadFeatureFlags2()
+    {
+        $app = new XRay($this->m_app);
+        $app->readFeatureFlags();
+        self::assertIsArray($app->m_featureFlags);
+
+        $flags = [];
+
+        foreach ($app->m_featureFlags as $flag) {
+            self::assertInstanceOf(FeatureFlagContract::class, $flag);
+            $flags[$flag->feature()] = $flag->variant();
+        }
+
+        self::assertEqualsCanonicalizing(
+            [
+                "feature-flag-1" => "variant-1",
+                "feature-flag-2" => null,
+            ],
+            $flags
+        );
     }
 }

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -9,8 +9,8 @@ use Bead\Exceptions\InvalidConfigurationException;
 use Bead\Exceptions\ServiceAlreadyBoundException;
 use Bead\Testing\XRay;
 use PHPUnit\Framework\TestCase;
-
 use Stringable as Stringable;
+
 use function is_array;
 
 class ApplicationTest extends TestCase
@@ -210,19 +210,19 @@ class ApplicationTest extends TestCase
     {
         $app = new XRay($this->m_app);
         $config = self::TestConfig;
-        unset($config['app']['feature-flags']);
+        unset($config["app"]["feature-flags"]);
         $app->m_config = $config;
         $app->readFeatureFlags();
         self::assertIsArray($app->m_featureFlags);
         self::assertCount(0, $app->m_featureFlags);
     }
 
-    /** Ensure reading feature flags throws when the config isn't an array */
+    /** Ensure reading feature flags throws when the config isn"t an array */
     public function testReadFeatureFlags4()
     {
         $app = new XRay($this->m_app);
         $config = self::TestConfig;
-        $config['app']['feature-flags'] = "invalid-flags";
+        $config["app"]["feature-flags"] = "invalid-flags";
         $app->m_config = $config;
         self::expectException(InvalidConfigurationException::class);
         self::expectExceptionMessage("Expecting array of feature flags, found string");
@@ -234,7 +234,7 @@ class ApplicationTest extends TestCase
     {
         $app = new XRay($this->m_app);
         $config = self::TestConfig;
-        $config['app']['feature-flags'][1] = "invalid-feature-name";
+        $config["app"]["feature-flags"][1] = "invalid-feature-name";
         $app->m_config = $config;
         self::expectException(InvalidConfigurationException::class);
         self::expectExceptionMessage("Expecting string feature flag, found int");

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -241,7 +241,7 @@ class ApplicationTest extends TestCase
         $app->readFeatureFlags();
     }
 
-    protected static function dataForTestReadFeatureFlags6(): iterable
+    public static function dataForTestReadFeatureFlags6(): iterable
     {
         yield "int" => [42, "int",];
         yield "double" => [3.1415927, "double",];
@@ -298,7 +298,7 @@ class ApplicationTest extends TestCase
         self::assertEqualsCanonicalizing(self::TestConfig["app"]["feature-flags"], $actualFlagsArray);
     }
 
-    protected static function definedFeatureFlags(): iterable
+    public static function definedFeatureFlags(): iterable
     {
         foreach (array_keys(self::TestConfig["app"]["feature-flags"]) as $feature) {
             yield $feature => [$feature];
@@ -320,7 +320,7 @@ class ApplicationTest extends TestCase
         self::assertTrue($this->m_app->hasFeatureFlag($feature));
     }
 
-    protected static function undefinedFeatureFlags(): iterable
+    public static function undefinedFeatureFlags(): iterable
     {
         yield "empty" => [""];
         yield "whitespace" => [" "];

--- a/test/Core/ApplicationTest.php
+++ b/test/Core/ApplicationTest.php
@@ -5,10 +5,12 @@ namespace BeadTests\Core;
 use Bead\Contracts\FeatureFlag as FeatureFlagContract;
 use Bead\Core\Application;
 use Bead\Core\FeatureFlag;
+use Bead\Exceptions\InvalidConfigurationException;
 use Bead\Exceptions\ServiceAlreadyBoundException;
 use Bead\Testing\XRay;
 use PHPUnit\Framework\TestCase;
 
+use Stringable as Stringable;
 use function is_array;
 
 class ApplicationTest extends TestCase
@@ -174,13 +176,16 @@ class ApplicationTest extends TestCase
     /** Ensure feature flags are not read from config until required */
     public function testReadFeatureFlags1()
     {
-        self::assertNull((new XRay($this->m_app))->m_featureFlags);
+        $app = new XRay($this->m_app);
+        $app->m_config = self::TestConfig;
+        self::assertNull($app->m_featureFlags);
     }
 
     /** Ensure feature flags are successfully read from the app config */
     public function testReadFeatureFlags2()
     {
         $app = new XRay($this->m_app);
+        $app->m_config = self::TestConfig;
         $app->readFeatureFlags();
         self::assertIsArray($app->m_featureFlags);
 
@@ -198,5 +203,176 @@ class ApplicationTest extends TestCase
             ],
             $flags
         );
+    }
+
+    /** Ensure feature flags are empty when the config doesn't have any */
+    public function testReadFeatureFlags3()
+    {
+        $app = new XRay($this->m_app);
+        $config = self::TestConfig;
+        unset($config['app']['feature-flags']);
+        $app->m_config = $config;
+        $app->readFeatureFlags();
+        self::assertIsArray($app->m_featureFlags);
+        self::assertCount(0, $app->m_featureFlags);
+    }
+
+    /** Ensure reading feature flags throws when the config isn't an array */
+    public function testReadFeatureFlags4()
+    {
+        $app = new XRay($this->m_app);
+        $config = self::TestConfig;
+        $config['app']['feature-flags'] = "invalid-flags";
+        $app->m_config = $config;
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage("Expecting array of feature flags, found string");
+        $app->readFeatureFlags();
+    }
+
+    /** Ensure reading feature flags throws when the config contains an invalid feature name. */
+    public function testReadFeatureFlags5()
+    {
+        $app = new XRay($this->m_app);
+        $config = self::TestConfig;
+        $config['app']['feature-flags'][1] = "invalid-feature-name";
+        $app->m_config = $config;
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage("Expecting string feature flag, found int");
+        $app->readFeatureFlags();
+    }
+
+    protected static function dataForTestReadFeatureFlags6(): iterable
+    {
+        yield "int" => [42, "int",];
+        yield "double" => [3.1415927, "double",];
+        yield "bool-true" => [true, "bool",];
+        yield "bool-false" => [false, "bool",];
+        yield "object" => [(object) [], "object",];
+        yield "stringable" => [
+            new class implements Stringable {
+                public function __toString(): string
+                {
+                    return "the-variant";
+                }
+            },
+            null,       // class name can't be determined
+        ];
+    }
+
+    /**
+     * Ensure reading feature flags throws when the config contains an invalid feature name.
+     *
+     * @dataProvider dataForTestReadFeatureFlags6
+     */
+    public function testReadFeatureFlags6(mixed $variant, ?string $expectedInvalidType = null)
+    {
+        $app = new XRay($this->m_app);
+        $config = self::TestConfig;
+        $config["app"]["feature-flags"]["feature-flag-3"] = $variant;
+        $app->m_config = $config;
+        self::expectException(InvalidConfigurationException::class);
+
+        if (null !== $expectedInvalidType) {
+            self::expectExceptionMessageMatches("/^Expecting string or null feature variant, found /");
+        } else {
+            self::expectExceptionMessage("Expecting string or null feature variant, found {$expectedInvalidType}");
+        }
+
+        $app->readFeatureFlags();
+    }
+
+    /** Ensure we retrieve the expected feature flags. */
+    public function testFeatureFlags1(): void
+    {
+        $app = new XRay($this->m_app);
+        $app->m_config = self::TestConfig;
+        $actualFlags = $this->m_app->featureFlags();
+        self::assertIsArray($actualFlags);
+        self::assertCount(2, $actualFlags);
+        $actualFlagsArray = [];
+
+        foreach ($actualFlags as $flag) {
+            $actualFlagsArray[$flag->feature()] = $flag->variant();
+        }
+
+        self::assertEqualsCanonicalizing(self::TestConfig["app"]["feature-flags"], $actualFlagsArray);
+    }
+
+    protected static function definedFeatureFlags(): iterable
+    {
+        foreach (array_keys(self::TestConfig["app"]["feature-flags"]) as $feature) {
+            yield $feature => [$feature];
+            yield "{$feature}-upper" => [mb_strtoupper($feature)];
+            yield "{$feature}-lower" => [mb_strtolower($feature)];
+            yield "{$feature}-title" => [mb_convert_case($feature, MB_CASE_TITLE)];
+        };
+    }
+
+    /**
+     * Ensure we can tell feature flags that are defined, case-insensitively.
+     *
+     * @dataProvider definedFeatureFlags
+     */
+    public function testHasFeatureFlag1(string $feature): void
+    {
+        $app = new Xray($this->m_app);
+        $app->m_config = self::TestConfig;
+        self::assertTrue($this->m_app->hasFeatureFlag($feature));
+    }
+
+    protected static function undefinedFeatureFlags(): iterable
+    {
+        yield "empty" => [""];
+        yield "whitespace" => [" "];
+        yield "multiple-whitespace" => ["   "];
+
+        foreach (array_keys(self::TestConfig["app"]["feature-flags"]) as $feature) {
+            yield "{$feature}-leading-space" => [" {$feature}"];
+            yield "{$feature}-trailing-space" => ["{$feature} "];
+            yield "{$feature}-surrounding-space" => [" {$feature} "];
+        }
+    }
+
+    /**
+     * Ensure we can tell feature flags that are not defined.
+     *
+     * @dataProvider undefinedFeatureFlags
+     */
+    public function testHasFeatureFlag2(string $feature): void
+    {
+        $app = new Xray($this->m_app);
+        $app->m_config = self::TestConfig;
+        self::assertFalse($this->m_app->hasFeatureFlag($feature));
+    }
+
+    /**
+     * Ensure we get the expected feature flag.
+     *
+     * @param string $feature
+     * @dataProvider definedFeatureFlags
+     */
+    public function testFeatureFlag1(string $feature): void
+    {
+        $app = new Xray($this->m_app);
+        $app->m_config = self::TestConfig;
+        $expectedVariant = self::TestConfig["app"]["feature-flags"][mb_strtolower($feature)];
+        $actualFlag = $this->m_app->featureFlag($feature);
+        self::assertInstanceOf(FeatureFlagContract::class, $actualFlag);
+        self::assertEquals(mb_strtolower($feature), $actualFlag->feature());
+        self::assertSame($expectedVariant, $actualFlag->variant());
+    }
+
+    /**
+     * Ensure we don't get the undefined feature flags.
+     *
+     * @param string $feature
+     * @dataProvider undefinedFeatureFlags
+     */
+    public function testFeatureFlag2(string $feature): void
+    {
+        $app = new Xray($this->m_app);
+        $app->m_config = self::TestConfig;
+        $actualFlag = $this->m_app->featureFlag($feature);
+        self::assertNull($actualFlag);
     }
 }

--- a/test/Core/FeatureFlagTest.php
+++ b/test/Core/FeatureFlagTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Core;
+
+use Bead\Core\FeatureFlag;
+use BeadTests\Framework\TestCase;
+
+class FeatureFlagTest extends TestCase
+{
+    private const FeatureName = "bead-feature-1";
+
+    private const Variant = "variant-1";
+
+    private FeatureFlag $m_testFlag;
+
+    public function setUp(): void
+    {
+        $this->m_testFlag = new FeatureFlag(self::FeatureName, self::Variant);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->m_testFlag);
+        parent::tearDown();
+    }
+
+    /** Ensure the constrcutor sets the feature. */
+    public function testConstructor1(): void
+    {
+        $flag = new FeatureFlag("bead-feature-2");
+        self::assertEquals("bead-feature-2", $flag->feature());
+    }
+
+    /** Ensure the variant is null by default. */
+    public function testConstructor2(): void
+    {
+        $flag = new FeatureFlag("bead-feature-2");
+        self::assertNull($flag->variant());
+    }
+
+    /** Ensure the variant can be set. */
+    public function testConstructor3(): void
+    {
+        $flag = new FeatureFlag("bead-feature-2", "the-variant");
+        self::assertEquals("the-variant", $flag->variant());
+    }
+
+    /** Ensure we get the expected feature name. */
+    public function testFeature1(): void
+    {
+        self::assertEquals(self::FeatureName, $this->m_testFlag->feature());
+    }
+
+    /** Ensure we can set the feature immutably. */
+    public function testWithFeature1(): void
+    {
+        $flag = $this->m_testFlag->withFeature("test-feature-2");
+        self::assertEquals("test-feature-2", $flag->feature());
+        self::assertNotSame($this->m_testFlag, $flag);
+        self::assertEquals(self::FeatureName, $this->m_testFlag->feature());
+    }
+
+    /** Ensure we get the expected variant name. */
+    public function testVariant1(): void
+    {
+        self::assertEquals(self::Variant, $this->m_testFlag->variant());
+    }
+
+    /** Ensure we can set the variant immutably. */
+    public function testWithVariant1(): void
+    {
+        $flag = $this->m_testFlag->withVariant("variant-2");
+        self::assertEquals("variant-2", $flag->variant());
+        self::assertNotSame($this->m_testFlag, $flag);
+        self::assertEquals(self::Variant, $this->m_testFlag->variant());
+    }
+
+    /** Ensure we can set the variant to null immutably. */
+    public function testWithVariant2(): void
+    {
+        $flag = $this->m_testFlag->withVariant(null);
+        self::assertNull($flag->variant());
+        self::assertNotSame($this->m_testFlag, $flag);
+        self::assertEquals(self::Variant, $this->m_testFlag->variant());
+    }
+}


### PR DESCRIPTION
`Application` base class now supports feature flags. Flags are read from the `app.php` config file. The config item `feature-flags` is optional, defaulting to an empty set of flags if not present. Client code can read the feature flags using `featureFlags()` to get all defined feature flags or `featureFlag(string)` to get an individual flag, and can test for flags using `hasFeatureFlag(string)`. Flags are loaded on-demand on the first call that requires them.