### PR TITLE
BEAD-225 Support 303 temporary redirects as well as 307s.

### DIFF
--- a/src/Web/Responses/RedirectResponse.php
+++ b/src/Web/Responses/RedirectResponse.php
@@ -22,14 +22,14 @@ class RedirectResponse implements Response
      * This is typically used when a request hasn't been processed because it needs to be processed by some other
      * resource. The user agent should repeat the original request, only with a different URI.
      */
-    public const TemporaryRedirect = 307;
+    public const TemporaryRepeatRedirect = 307;
 
     /**
      * @var int HTTP status code for temporary redirects using the GET HTTP method regardless of the method of the
-     * orignal request.
+     * original request.
      *
      * This is typically used when a request has succeeded and you want to redirect the user agent to a different
-     * resource.
+     * resource as a result.
      */
     public const TemporaryGetRedirect = 303;
 

--- a/src/Web/Responses/RedirectResponse.php
+++ b/src/Web/Responses/RedirectResponse.php
@@ -16,11 +16,25 @@ class RedirectResponse implements Response
     /** @var int HTTP status code for permanent redirects. */
     public const PermanentRedirect = 308;
 
-    /** @var int HTTP status code for temporary redirects. */
+    /**
+     * @var int HTTP status code for temporary redirects using the same HTTP method as the original request.
+     *
+     * This is typically used when a request hasn't been processed because it needs to be processed by some other
+     * resource. The user agent should repeat the original request, only with a different URI.
+     */
     public const TemporaryRedirect = 307;
 
+    /**
+     * @var int HTTP status code for temporary redirects using the GET HTTP method regardless of the method of the
+     * orignal request.
+     *
+     * This is typically used when a request has succeeded and you want to redirect the user agent to a different
+     * resource.
+     */
+    public const TemporaryGetRedirect = 303;
+
     /** @var int The default HTTP status code to use. */
-    public const DefaultRedirectCode = self::TemporaryRedirect;
+    public const DefaultRedirectCode = self::TemporaryGetRedirect;
 
     /** @var int The HTTP status code. */
     private int $m_code;

--- a/test/Web/Responses/RedirectResponseTest.php
+++ b/test/Web/Responses/RedirectResponseTest.php
@@ -62,11 +62,11 @@ class RedirectResponseTest extends TestCase
             "content-type: ",
         ];
 
-        $httpResponseCode = function(int $statusCode) use ($response): void {
+        $httpResponseCode = function (int $statusCode) use ($response): void {
             TestCase::assertEquals($response->statusCode(), $statusCode);
         };
 
-        $header = function(string $header, bool $replace) use (&$expectedHeaders): void {
+        $header = function (string $header, bool $replace) use (&$expectedHeaders): void {
             $expected = array_shift($expectedHeaders);
             TestCase::assertEquals($expected, $header);
             TestCase::assertTrue($replace);

--- a/test/Web/Responses/RedirectResponseTest.php
+++ b/test/Web/Responses/RedirectResponseTest.php
@@ -8,7 +8,7 @@ use BeadTests\Framework\TestCase;
 class RedirectResponseTest extends TestCase
 {
     /** @var string The test redirect URL. */
-    private const string TestUrl = "/redirect";
+    private const TestUrl = "/redirect";
 
     /** @var RedirectResponse The test fixture. */
     private RedirectResponse $response;
@@ -24,7 +24,7 @@ class RedirectResponseTest extends TestCase
         parent::tearDown();
     }
 
-    /** Ensure the constructor uses the defalt HTTP response code. */
+    /** Ensure the constructor uses the default HTTP response code. */
     public function testConstructor1(): void
     {
         self::assertEquals(RedirectResponse::DefaultRedirectCode, $this->response->statusCode());

--- a/test/Web/Responses/RedirectResponseTest.php
+++ b/test/Web/Responses/RedirectResponseTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace BeadTests\Web\Responses;
+
+use Bead\Web\Responses\RedirectResponse;
+use BeadTests\Framework\TestCase;
+
+class RedirectResponseTest extends TestCase
+{
+    /** @var string The test redirect URL. */
+    private const string TestUrl = "/redirect";
+
+    /** @var RedirectResponse The test fixture. */
+    private RedirectResponse $response;
+
+    public function setUp(): void
+    {
+        $this->response = new RedirectResponse(self::TestUrl);
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->response);
+        parent::tearDown();
+    }
+
+    /** Ensure the constructor uses the defalt HTTP response code. */
+    public function testConstructor1(): void
+    {
+        self::assertEquals(RedirectResponse::DefaultRedirectCode, $this->response->statusCode());
+    }
+
+    /** Ensure the constructor uses the provided URL and HTTP status code. */
+    public function testConstructor2(): void
+    {
+        $response = new RedirectResponse("/go/somewhere/else", RedirectResponse::PermanentRedirect);
+        self::assertEquals("/go/somewhere/else", $response->url());
+        self::assertEquals(RedirectResponse::PermanentRedirect, $response->statusCode());
+    }
+
+    /** Ensure we get the expected redirect location header. */
+    public function testHeaders1(): void
+    {
+        self::assertEquals(["location" => "/redirect"], $this->response->headers());
+    }
+
+    /** Ensure we can set the redirect URL. */
+    public function testSetUrl(): void
+    {
+        self::assertNotEquals("/go/somewhere/else", $this->response->url());
+        $this->response->setUrl("/go/somewhere/else");
+        self::assertEquals("/go/somewhere/else", $this->response->url());
+    }
+
+    /** Ensure the HTTP response code and headers are set. */
+    public function testSend1(): void
+    {
+        $response = $this->response;
+
+        $expectedHeaders = [
+            "location: /redirect",
+            "content-type: ",
+        ];
+
+        $httpResponseCode = function(int $statusCode) use ($response): void {
+            TestCase::assertEquals($response->statusCode(), $statusCode);
+        };
+
+        $header = function(string $header, bool $replace) use (&$expectedHeaders): void {
+            $expected = array_shift($expectedHeaders);
+            TestCase::assertEquals($expected, $header);
+            TestCase::assertTrue($replace);
+        };
+
+        $this->mockFunction("http_response_code", $httpResponseCode);
+        $this->mockFunction("header", $header);
+        $this->response->send();
+        self::assertEmpty($expectedHeaders);
+    }
+}


### PR DESCRIPTION
Adds direct support for 303 (use GET to fetch this URI) redirects as well as 307 (repeat your previous request with this URI) redirects.
Adds unit test.