### PR TITLE
Typed array validation rule and partition() iterable helper

### DIFF
--- a/src/Helpers/Iterable.php
+++ b/src/Helpers/Iterable.php
@@ -350,3 +350,28 @@ function fill(int $count, callable $createValue, ?callable $createKey = null): i
         yield ($createKey ? $createKey($idx) : $idx) => $createValue($idx);
     }
 }
+
+/**
+ * Partition the items in an iterable according to a classification function.
+ *
+ * @param iterable $collection The items to partition.
+ * @param callable $classifier The classification function that identifies which partition each value belongs in.
+ *
+ * @return array The partitioned data.
+ */
+function partition(iterable $collection, callable $classifier): array
+{
+    $partitions = [];
+
+    foreach ($collection as $item) {
+        $key = $classifier($item);
+
+        if (array_key_exists($key, $partitions)) {
+            $partitions[$key][] = $item;
+        } else {
+            $partitions[$key] = [$item];
+        }
+    }
+
+    return $partitions;
+}

--- a/src/Validation/Rules/IsTypedArray.php
+++ b/src/Validation/Rules/IsTypedArray.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @author Darren Edale
+ * @version 0.9.2
+ * @date May 2022
+ */
+
+declare(strict_types=1);
+
+namespace Bead\Validation\Rules;
+
+use Bead\Validation\Rule;
+use Bead\Helpers\Iterable as IterableHelpers;
+
+use function Bead\Helpers\I18n\tr;
+
+/**
+ * Validator rule to ensure that some data is an array of items of a given type.
+ */
+class IsTypedArray extends IsArray
+{
+    /** @var string The type or class required for the array's items. */
+    private string $requiredType;
+
+    /** @var string The type defined by the rule. */
+    private string $type;
+
+    /**
+     * Initialise a new instance of the rule.
+     *
+     * @param string $type The type or class that all items must match.
+     */
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+
+        // handle these as special cases since the types don't match what gettype() returns - by recognising both forms
+        // we're future-proofing against PHP bringing gettype() into line with the actual types
+        $this->requiredType = match($type) {
+            "int", "integer" => gettype(42),
+            "float", "double" => gettype(3.14),
+            "boolean", "bool" => gettype(true),
+            default => $type,
+        };
+    }
+
+    /**
+     * Check some data against the rule.
+     *
+     * @param string $field The field name of the data being checked.
+     * @param mixed $data The data to check.
+     *
+     * @return bool `true` if the data is an array, `false` otherwise.
+     */
+    public function passes(string $field, mixed $data): bool
+    {
+        return parent::passes($field, $data) && IterableHelpers\all($data, fn (mixed $value) => $this->isCorrectType($value));
+    }
+
+    /**
+     * Fetch the default message for when the data does not pass the rule.
+     *
+     * @param string $field The field under validation.
+     *
+     * @return string The message.
+     */
+    public function message(string $field): string
+    {
+        return tr("The %1 field must be an array of %2 values.", __FILE__, __LINE__, $field, $this->type);
+    }
+
+    /** Helper to check a value matches the requied type. */
+    protected function isCorrectType(mixed $value): bool
+    {
+        return $this->requiredType === gettype($value) || (is_object($value) && get_class($value) === $this->requiredType);
+    }
+}

--- a/src/Validation/Rules/IsTypedArray.php
+++ b/src/Validation/Rules/IsTypedArray.php
@@ -37,7 +37,7 @@ class IsTypedArray extends IsArray
 
         // handle these as special cases since the types don't match what gettype() returns - by recognising both forms
         // we're future-proofing against PHP bringing gettype() into line with the actual types
-        $this->requiredType = match($type) {
+        $this->requiredType = match ($type) {
             "int", "integer" => gettype(42),
             "float", "double" => gettype(3.14),
             "boolean", "bool" => gettype(true),

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Bead\Validation;
 
 use ArgumentCountError;
+use Bead\Validation\Rules\IsTypedArray;
 use DateTime;
 use DateTimeImmutable;
 use Bead\Exceptions\ValidationException;
@@ -100,6 +101,7 @@ class Validator
         "number" => Number::class,
         "string" => IsString::class,
         "array" => IsArray::class,
+        "typed-array" => IsTypedArray::class,
         "bool" => IsBoolean::class,
         "true" => IsTrue::class,
         "false" => IsFalse::class,

--- a/test/Helpers/IterableTest.php
+++ b/test/Helpers/IterableTest.php
@@ -19,6 +19,7 @@ use function Bead\Helpers\Iterable\implode;
 use function Bead\Helpers\Iterable\isSubsetOf;
 use function Bead\Helpers\Iterable\map;
 use function Bead\Helpers\Iterable\none;
+use function Bead\Helpers\Iterable\partition;
 use function Bead\Helpers\Iterable\recursiveCount;
 use function Bead\Helpers\Iterable\reduce;
 use function Bead\Helpers\Iterable\some;
@@ -1695,5 +1696,33 @@ final class IterableTest extends TestCase
 
         $actual = recursiveCount($iterable);
         self::assertEquals($expected, $actual);
+    }
+
+    /** Ensure we can partition with integer keys. */
+    public function testPartition1(): void
+    {
+        $data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        $classifier = static fn (int $value): int => (int) floor(($value - 1) / 3);
+        [$partition1, $partition2, $partition3,] = partition($data, $classifier);
+        self::assertSame([1, 2, 3,], $partition1);
+        self::assertSame([4, 5, 6,], $partition2);
+        self::assertSame([7, 8, 9,], $partition3);
+    }
+
+    /** Ensure we can partition with string keys. */
+    public function testPartition2(): void
+    {
+        $data = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+        $classifier = static fn (int $value): string => match (true) {
+            1 === ($value % 2) => "odd",
+            0 === ($value % 3) => "even-multiple-of-three",
+            default => "other",
+        };
+
+        ["odd" => $odd, "even-multiple-of-three" => $multiplesOfThree, "other" => $other,] = partition($data, $classifier);
+        self::assertSame([1, 3, 5, 7, 9,], $odd);
+        self::assertSame([6,], $multiplesOfThree);
+        self::assertSame([2, 4, 8,], $other);
     }
 }

--- a/test/Validation/Rules/IsArrayTest.php
+++ b/test/Validation/Rules/IsArrayTest.php
@@ -10,7 +10,7 @@ use BeadTests\Framework\RuleTestCase;
 use TypeError;
 
 /**
- * Test case for the IsString validator rule.
+ * Test case for the IsArray validator rule.
  */
 class IsArrayTest extends RuleTestCase
 {

--- a/test/Validation/Rules/IsTypedArrayTest.php
+++ b/test/Validation/Rules/IsTypedArrayTest.php
@@ -110,10 +110,10 @@ class IsTypedArrayTest extends RuleTestCase
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
-                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
-                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
             ],
         ];
@@ -130,10 +130,10 @@ class IsTypedArrayTest extends RuleTestCase
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
-                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
-                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
                 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
             ],
         ];
@@ -151,7 +151,7 @@ class IsTypedArrayTest extends RuleTestCase
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
-                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, 
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
@@ -176,7 +176,7 @@ class IsTypedArrayTest extends RuleTestCase
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
-                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, 
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
                 true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
@@ -435,5 +435,4 @@ class IsTypedArrayTest extends RuleTestCase
         $rule = $this->ruleInstance($type);
         self::assertFalse($rule->passes("field", $data));
     }
-
 }

--- a/test/Validation/Rules/IsTypedArrayTest.php
+++ b/test/Validation/Rules/IsTypedArrayTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Validation\Rules;
+
+use Bead\Validation\Rule;
+use Bead\Validation\Rules\IsTypedArray;
+use BeadTests\Framework\RuleTestCase;
+use TypeError;
+
+/**
+ * Test case for the IsTypedArray validator rule.
+ */
+class IsTypedArrayTest extends RuleTestCase
+{
+    protected function ruleInstance(string $type = "string"): Rule
+    {
+        return new IsTypedArray($type);
+    }
+
+    /**
+     * Data provider for testPasses1() - data that should pass the validation rule.
+     *
+     * @return iterable The test data.
+     */
+    public function dataForTestPasses1(): iterable
+    {
+        yield "short-string-array" => ["string", ["first", "second", "third",],];
+        yield "empty-string-array" => ["string", [],];
+        yield "large-string-array" => [
+            "string",
+            [
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+                "first", "second", "third", "first", "second", "third", "first", "second", "third",
+            ],
+        ];
+
+        yield "short-int-array" => ["int", [1, 2, 3,],];
+        yield "empty-int-array" => ["int", [],];
+        yield "large-int-array" => [
+            "int",
+            [
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3,
+            ],
+        ];
+
+        yield "short-integer-array" => ["integer", [1, 2, 3,],];
+        yield "empty-integer-array" => ["integer", [],];
+        yield "large-integer-array" => [
+            "integer",
+            [
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3,
+                1, 2, 3, 1, 2, 3, 1, 2, 3,
+            ],
+        ];
+
+        yield "short-float-array" => ["float", [1.1, 2.2, 3.3,],];
+        yield "empty-float-array" => ["float", [],];
+        yield "large-float-array" => [
+            "float",
+            [
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+            ],
+        ];
+
+        yield "short-double-array" => ["double", [1.1, 2.2, 3.3,],];
+        yield "empty-double-array" => ["double", [],];
+        yield "large-double-array" => [
+            "double",
+            [
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 
+                1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3,
+            ],
+        ];
+
+        yield "short-bool-array" => ["bool", [true, false, false,],];
+        yield "empty-bool-array" => ["bool", [],];
+        yield "large-bool-array" => [
+            "bool",
+            [
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, 
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false,
+            ],
+        ];
+
+        yield "short-boolean-array" => ["boolean", [true, false, false,],];
+        yield "empty-boolean-array" => ["boolean", [],];
+        yield "large-boolean-array" => [
+            "boolean",
+            [
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false, 
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false, true, false, false,
+                true, false, false, true, false, false, true, false, false, true, false, false,
+            ],
+        ];
+
+        yield "short-array-array" => ["array", [[1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],],];
+        yield "empty-array-array" => ["array", [],];
+        yield "large-array-array" => [
+            "array",
+            [
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+                [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",], [1, 2, 3,], [1.1, 2.2, 3.3,], ["a", "B", "c",],
+            ],
+        ];
+
+        $object = new self();
+
+        yield "short-class-array" => [self::class, [$object, $object, $object,],];
+        yield "empty-class-array" => [self::class, [],];
+        yield "large-class-array" => [
+            self::class,
+            [
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+            ],
+        ];
+
+        yield "short-object-array" => ["object", [$object, $object, $object,],];
+        yield "empty-object-array" => ["object", [],];
+        yield "large-object-array" => [
+            "object",
+            [
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+                $object, $object, $object, $object, $object, $object,
+            ],
+        ];
+    }
+
+    /**
+     * Ensure passes() accepts valid arrays.
+     *
+     * @dataProvider dataForTestPasses1
+     */
+    public function testPasses1(string $type, array $data): void
+    {
+        $rule = $this->ruleInstance($type);
+        self::assertTrue($rule->passes("field", $data));
+    }
+
+    /**
+     * Data provider for testPasses1() - data that should not pass the validation rule.
+     *
+     * @return iterable The test data.
+     */
+    public function dataForTestPasses2(): iterable
+    {
+        // non-array values
+        foreach (["int", "integer", "float", "double", "bool", "boolean", "string", self::class, "object"] as $type) {
+            yield "{$type}-int" => [$type, 1,];
+            yield "{$type}-float" => [$type, 1.1,];
+            yield "{$type}-bool" => [$type, true,];
+            yield "{$type}-string" => [$type, "string",];
+            yield "{$type}-class" => [$type, new self(),];
+        }
+
+        $object = new self();
+
+        yield "int-array-float" => ["int", [1, 2, 1.1, 3,],];
+        yield "int-array-string" => ["int", [1, 2, "string", 3,],];
+        yield "int-array-bool" => ["int", [1, 2, true, 3,],];
+        yield "int-array-array" => ["int", [1, 2, [], 3,],];
+        yield "int-array-class" => ["int", [1, 2, $object, 3,],];
+
+        yield "integer-array-float" => ["integer", [1, 2, 1.1, 3,],];
+        yield "integer-array-string" => ["integer", [1, 2, "string", 3,],];
+        yield "integer-array-bool" => ["integer", [1, 2, true, 3,],];
+        yield "integer-array-array" => ["integer", [1, 2, [], 3,],];
+        yield "integer-array-class" => ["integerint", [1, 2, $object, 3,],];
+
+        yield "float-array-int" => ["float", [1.1, 2.2, 1, 3.3,],];
+        yield "float-array-string" => ["float", [1.1, 2.2, "string", 3.3,],];
+        yield "float-array-bool" => ["float", [1.1, 2.2, true, 3.3,],];
+        yield "float-array-array" => ["float", [1.1, 2.2, [], 3.3,],];
+        yield "float-array-class" => ["float", [1.1, 2.2, $object, 3.3,],];
+
+        yield "double-array-int" => ["double", [1.1, 2.2, 1, 3.3,],];
+        yield "double-array-string" => ["double", [1.1, 2.2, "string", 3.3,],];
+        yield "double-array-bool" => ["double", [1.1, 2.2, true, 3.3,],];
+        yield "double-array-array" => ["double", [1.1, 2.2, [], 3.3,],];
+        yield "double-array-class" => ["double", [1.1, 2.2, $object, 3.3,],];
+
+        yield "bool-array-int" => ["bool", [true, true, 1, false,],];
+        yield "bool-array-float" => ["bool", [true, true, 1.1, false,],];
+        yield "bool-array-string" => ["bool", [true, true, "string", false,],];
+        yield "bool-array-array" => ["bool", [true, true, [], false,],];
+        yield "bool-array-class" => ["bool", [true, true, $object, false,],];
+
+        yield "boolean-array-int" => ["boolean", [true, true, 1, false,],];
+        yield "boolean-array-float" => ["boolean", [true, true, 1.1, false,],];
+        yield "boolean-array-string" => ["boolean", [true, true, "string", false,],];
+        yield "boolean-array-array" => ["boolean", [true, true, [], false,],];
+        yield "boolean-array-class" => ["boolean", [true, true, $object, false,],];
+
+        yield "string-array-int" => ["string", ["one", "three", 1, "five",],];
+        yield "string-array-float" => ["string", ["one", "three", 1.1, "five",],];
+        yield "string-array-bool" => ["string", ["one", "three", false, "five",],];
+        yield "string-array-array" => ["string", ["one", "three", [], "five",],];
+        yield "string-array-class" => ["string", ["one", "three", $object, "five",],];
+
+        yield "array-array-int" => ["array", [["one",], ["three",], 1, ["five",],],];
+        yield "array-array-float" => ["array", [["one",], ["three",], 1.1, ["five",],],];
+        yield "array-array-bool" => ["array", [["one",], ["three",], false, ["five",],],];
+        yield "array-array-string" => ["array", [["one",], ["three",], "string", ["five",],],];
+        yield "array-array-class" => ["array", [["one",], ["three",], $object, ["five",],],];
+
+        yield "class-array-int" => ["array", [$object, $object, 1, $object,],];
+        yield "class-array-float" => ["array", [$object, $object, 1.1, $object,],];
+        yield "class-array-bool" => ["array", [$object, $object, false, $object,],];
+        yield "class-array-string" => ["array", [$object, $object, "string", $object,],];
+        yield "class-array-array" => ["array", [$object, $object, [$object], $object,],];
+    }
+
+    /**
+     * Ensure passes() rejects invalid arrays.
+     *
+     * @dataProvider dataForTestPasses2
+     */
+    public function testPasses2(string $type, mixed $data): void
+    {
+        $rule = $this->ruleInstance($type);
+        self::assertFalse($rule->passes("field", $data));
+    }
+
+}


### PR DESCRIPTION
`IsTypedArray` validation rule requires an array whose items are all of a given type. The type can be a scalar built-in, a class built-in or a user-defined class.

`partition()` helper function takes any iterable and classifies them according to a classification function. It returns the items from the iterable partitioned into _n_ arrays, where _n_ is the number of unique return values from the classification function given each of the items in the array. Each item ends up in just one of the returned arrays, according to the return value of the classification function for that item.
