### PR TITLE
BEAD-249 Add and use Web\Header class

### DIFF
--- a/src/Contracts/Web/Header.php
+++ b/src/Contracts/Web/Header.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Contracts\Web;
+
+/** Interface for HTTP message headers. */
+interface Header
+{
+    /**
+     * The header's name.
+     *
+     * The name never has leading or trailing whitespace.
+     */
+    public function name(): string;
+
+    /** The header's value. */
+    public function value(): string;
+
+    /** Retrieve the full header line, without the trailing CRLF delimiter. */
+    public function line(): string;
+}

--- a/src/Contracts/Web/Response.php
+++ b/src/Contracts/Web/Response.php
@@ -5,9 +5,15 @@ namespace Bead\Contracts\Web;
 interface Response
 {
     public function statusCode(): int;
+
     public function reasonPhrase(): string;
+
     public function contentType(): string;
+
+    /** @return Header[] */
     public function headers(): array;
+
     public function content(): string;
+
     public function send(): void;
 }

--- a/src/Web/Header.php
+++ b/src/Web/Header.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bead\Web;
+
+use Bead\Contracts\Web\Header as HeaderContract;
+use RuntimeException;
+
+/** An immutable implementation of the Web\Header contract. */
+class Header implements HeaderContract
+{
+    /** @var string The header name. */
+    private string $name;
+
+    /** @var string The header value. */
+    private string $value;
+
+    /**
+     * PCRE pattern to identify valid RFC-822 header field names.
+     *
+     * See https://datatracker.ietf.org/doc/html/rfc822#section-3.2
+     */
+    private const Rfc822HeaderNamePattern = "/^[!#$%&'*+\\-0-9A-Z^_`a-z|~]+\$/";
+
+    /**
+     * Initialise a new header with a name and value.
+     *
+     * @param string $name Must be a valid RFC822 message header name. Leading and trailing whitespace will be trimmed
+     * before checking.
+     * @param string $value The header's value.
+     */
+    public function __construct(string $name, string $value)
+    {
+        $name = trim($name);
+        self::checkName($name);
+        $this->name = mb_strtolower($name, "UTF-8");
+        $this->value = $value;
+    }
+
+    /** Throw if a string contains an invalid RFC822 header name. */
+    private static function checkName(string $name): void
+    {
+        if (!self::isValidName($name)) {
+            throw new RuntimeException("Expected valid header name, found \"{$name}\"");
+        }
+    }
+
+    /** Check whether a string contains a valid RFC822 header name. */
+    public static function isValidName(string $name): bool
+    {
+        return 1 === preg_match(self::Rfc822HeaderNamePattern, $name);
+    }
+
+    /** The header name. */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /** Fetch a clone of the header with a different name. */
+    public function withName(string $name): self
+    {
+        $name = trim($name);
+        self::checkName($name);
+        $clone = clone $this;
+        $clone->name = $name;
+        return $clone;
+    }
+
+    /** The header value. */
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    /** Fetch a clone of the header with a different value. */
+    public function withValue(string $value): self
+    {
+        $clone = clone $this;
+        $clone->value = $value;
+        return $clone;
+    }
+
+    /** The full header line. */
+    public function line(): string
+    {
+        return "{$this->name()}: {$this->value()}";
+    }
+}

--- a/src/Web/Header.php
+++ b/src/Web/Header.php
@@ -26,13 +26,11 @@ class Header implements HeaderContract
     /**
      * Initialise a new header with a name and value.
      *
-     * @param string $name Must be a valid RFC822 message header name. Leading and trailing whitespace will be trimmed
-     * before checking.
+     * @param string $name Must be a valid RFC822 message header name.
      * @param string $value The header's value.
      */
     public function __construct(string $name, string $value)
     {
-        $name = trim($name);
         self::checkName($name);
         $this->name = mb_strtolower($name, "UTF-8");
         $this->value = $value;
@@ -61,7 +59,6 @@ class Header implements HeaderContract
     /** Fetch a clone of the header with a different name. */
     public function withName(string $name): self
     {
-        $name = trim($name);
         self::checkName($name);
         $clone = clone $this;
         $clone->name = $name;

--- a/src/Web/Header.php
+++ b/src/Web/Header.php
@@ -28,6 +28,7 @@ class Header implements HeaderContract
      *
      * @param string $name Must be a valid RFC822 message header name.
      * @param string $value The header's value.
+     * @throws RuntimeException if the provided header name is not valid.
      */
     public function __construct(string $name, string $value)
     {
@@ -36,7 +37,7 @@ class Header implements HeaderContract
         $this->value = $value;
     }
 
-    /** Throw if a string contains an invalid RFC822 header name. */
+    /** @throws RuntimeException if the provided header name is not valid. */
     private static function checkName(string $name): void
     {
         if (!self::isValidName($name)) {
@@ -56,7 +57,10 @@ class Header implements HeaderContract
         return $this->name;
     }
 
-    /** Fetch a clone of the header with a different name. */
+    /**
+     * Fetch a clone of the header with a different name.
+     * @throws RuntimeException if the provided header name is not valid.
+     */
     public function withName(string $name): self
     {
         self::checkName($name);

--- a/src/Web/Request.php
+++ b/src/Web/Request.php
@@ -4,6 +4,7 @@ namespace Bead\Web;
 
 use InvalidArgumentException;
 use TypeError;
+use function Bead\Helpers\Iterable\all;
 
 /**
  * Abstract representation of an incoming HTTP request.
@@ -33,7 +34,7 @@ class Request
     /** @var array<string,UploadedFile> The files uploaded with the request. */
     private array $m_files = [];
 
-    /** @var array<string, string> The request's HTTP headers. */
+    /** @var Header[] The request's HTTP headers. */
     private array $m_headers = [];
 
     /** @var string The full request URL. */
@@ -526,12 +527,19 @@ class Request
      *
      * @param string $name The header requested.
      *
-     * @return string|null The header value, or `null` if the header is not set.
+     * @return string|null The value of the first header with a matching name, or `null` if the header is not set.
      */
     public function header(string $name): ?string
     {
         $name = mb_strtolower($name, "UTF-8");
-        return $this->m_headers[$name] ?? $this->m_headers[str_replace("-", "_", $name)] ?? null;
+
+        foreach ($this->m_headers as $header) {
+            if (mb_strtolower($header->name(), "UTF-8") === $name) {
+                return $header->value();
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -544,7 +552,7 @@ class Request
     public function isAjax(): bool
     {
         // FE frameworks need to set this header. many popular frameworks do so
-        return "XMLHttpRequest" == $this->header("x_requested_with");
+        return "XMLHttpRequest" === $this->header("x-requested-with");
     }
 
     /** @throws InvalidArgumentException if the IP is not valid. */
@@ -618,11 +626,11 @@ class Request
             $req->m_files = UploadedFile::allUploadedFiles();
 
             foreach ($_SERVER as $key => $value) {
-                if ("HTTP_" === substr($key, 0, 5)) {
-                    $req->m_headers[mb_strtolower(substr($key, 5), "UTF-8")] = $value;
+                if (str_starts_with($key, "HTTP_")) {
+                    $req->m_headers[] = new Header(str_replace("_", "-", substr($key, 5)), $value);
                 } else {
                     if (in_array($key, ["CONTENT_TYPE", "CONTENT_LENGTH", "CONTENT_MD5",])) {
-                        $req->m_headers[strtolower($key)] = $value;
+                        $req->m_headers[] = new Header(str_replace("_", "-", $key), $value);
                     }
                 }
             }

--- a/src/Web/Request.php
+++ b/src/Web/Request.php
@@ -4,7 +4,6 @@ namespace Bead\Web;
 
 use InvalidArgumentException;
 use TypeError;
-use function Bead\Helpers\Iterable\all;
 
 /**
  * Abstract representation of an incoming HTTP request.

--- a/src/Web/Responses/DoesntHaveHeaders.php
+++ b/src/Web/Responses/DoesntHaveHeaders.php
@@ -2,6 +2,8 @@
 
 namespace Bead\Web\Responses;
 
+use Bead\Contracts\Web\Header;
+
 /**
  * Trait for responses that don't have any headers (other than content-type.
  *
@@ -11,7 +13,7 @@ trait DoesntHaveHeaders
 {
     /**
      * The (empty) array of headers.
-     * @return array The headers.
+     * @return Header[] The headers.
      */
     public function headers(): array
     {

--- a/src/Web/Responses/DownloadResponse.php
+++ b/src/Web/Responses/DownloadResponse.php
@@ -2,9 +2,9 @@
 
 namespace Bead\Web\Responses;
 
-/**
- * Send a response to be downloaded as a file.
- */
+use Bead\Contracts\Web\Header;
+
+/** Send a response to be downloaded as a file. */
 class DownloadResponse extends AbstractResponse
 {
     /** @var string The default content-type header value for responses. */
@@ -16,7 +16,7 @@ class DownloadResponse extends AbstractResponse
     /** @var string The content for the download. */
     private string $m_data = "";
 
-    /** @var array The headers. */
+    /** @var Header[] The headers. */
     private array $m_headers = [];
 
     /**
@@ -81,7 +81,7 @@ class DownloadResponse extends AbstractResponse
     /**
      * Fluently set the headers for the download response.
      *
-     * @param array<string,string> $headers The response headers.
+     * @param Header[] $headers The response headers.
      *
      * @return $this This Response object for further method chaining.
      */
@@ -94,7 +94,7 @@ class DownloadResponse extends AbstractResponse
     /**
      * Set the download response HTTP headers.
      *
-     * @param array<string,string> $headers The headers.
+     * @param Header[] $headers The headers.
      */
     public function setHeaders(array $headers): void
     {
@@ -106,7 +106,7 @@ class DownloadResponse extends AbstractResponse
      *
      * Regardless of whether the `content-disposition` header has been set manually, the `content-disposition` in the
      * returned array is always set to 'attachment; filename="..."' (where ... is the filename set using `setFileName()`.
-     * @return array<string,string>
+     * @return Header[]
      */
     public function headers(): array
     {

--- a/src/Web/Responses/FileDownloadResponse.php
+++ b/src/Web/Responses/FileDownloadResponse.php
@@ -2,9 +2,7 @@
 
 namespace Bead\Web\Responses;
 
-/**
- * Response to stream a file to the client.
- */
+/** Response to stream a file to the client. */
 class FileDownloadResponse extends DownloadResponse
 {
     /** @var string The path to the file to stream. */
@@ -55,9 +53,7 @@ class FileDownloadResponse extends DownloadResponse
         return $this;
     }
 
-    /**
-     * Send the response.
-     */
+    /** Send the response. */
     public function send(): void
     {
         http_response_code($this->statusCode());

--- a/src/Web/Responses/NaivelySendsContent.php
+++ b/src/Web/Responses/NaivelySendsContent.php
@@ -2,11 +2,10 @@
 
 namespace Bead\Web\Responses;
 
+use Bead\Contracts\Web\Header;
 use Bead\Exceptions\Http\HttpException;
 
-/**
- * Trait for responses that simply send the status, headers and content without any further transformation.
- */
+/** Trait for responses that simply send the status, headers and content without any further transformation. */
 trait NaivelySendsContent
 {
     use SendsHeaders;
@@ -26,7 +25,7 @@ trait NaivelySendsContent
 
     /**
      * Constrain the trait to classes that implement this method.
-     * @return array<string,string> The HTTP headers.
+     * @return Header[] The HTTP headers.
      */
     abstract public function headers(): array;
 
@@ -44,10 +43,10 @@ trait NaivelySendsContent
     public function send(): void
     {
         header("HTTP/1.1 {$this->statusCode()} {$this->sanitisedReasonPhrase()}");
-        header("content-type: {$this->contentType()}", true);
+        header("Content-Type: {$this->contentType()}");
 
-        foreach ($this->headers() as $header => $value) {
-            header("{$header}: {$value}", true);
+        foreach ($this->headers() as $header) {
+            header($header->line(), false);
         }
 
         echo $this->content();

--- a/src/Web/Responses/RedirectResponse.php
+++ b/src/Web/Responses/RedirectResponse.php
@@ -73,6 +73,7 @@ class RedirectResponse implements Response
      */
     public function headers(): array
     {
+        /** @psalm-suppress MissingThrowsDocblock - "location" is known to be a valid header name. */
         return [new Header("location", $this->url()),];
     }
 

--- a/src/Web/Responses/RedirectResponse.php
+++ b/src/Web/Responses/RedirectResponse.php
@@ -3,6 +3,7 @@
 namespace Bead\Web\Responses;
 
 use Bead\Contracts\Web\Response;
+use Bead\Web\Header;
 
 /**
  * A response to redirect the user agent to a different URL.
@@ -72,7 +73,7 @@ class RedirectResponse implements Response
      */
     public function headers(): array
     {
-        return ["location" => $this->url(),];
+        return [new Header("location", $this->url()),];
     }
 
     /**
@@ -95,9 +96,7 @@ class RedirectResponse implements Response
         $this->m_url = $url;
     }
 
-    /**
-     * Send the redirect response.
-     */
+    /** Send the redirect response. */
     public function send(): void
     {
         http_response_code($this->statusCode());

--- a/src/Web/Responses/SendsHeaders.php
+++ b/src/Web/Responses/SendsHeaders.php
@@ -2,6 +2,8 @@
 
 namespace Bead\Web\Responses;
 
+use Bead\Contracts\Web\Header;
+
 /**
  * Trait to endow a response with a method to send the HTTP headers.
  *
@@ -12,23 +14,21 @@ trait SendsHeaders
 {
     /**
      * Constrain the trait to classes that implement the headers() method.
+     *
+     * @return Header[]
      */
     abstract public function headers(): array;
 
-    /**
-     * Constrain the trait to classes that implement the contentType() method.
-     */
+    /** Constrain the trait to classes that implement the contentType() method. */
     abstract public function contentType(): string;
 
-    /**
-     * Send the headers.
-     */
+    /** Send the headers. */
     protected function sendHeaders(): void
     {
-        foreach ($this->headers() as $header => $value) {
-            header("{$header}: {$value}", true);
+        foreach ($this->headers() as $header) {
+            header($header->line(), false);
         }
 
-        header("content-type: {$this->contentType()}", true);
+        header("Content-Type: {$this->contentType()}", true);
     }
 }

--- a/test/Web/HeaderTest.php
+++ b/test/Web/HeaderTest.php
@@ -6,38 +6,134 @@ namespace BeadTests\Web;
 
 use Bead\Web\Header;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
-/** TODO implement. */
+/** @covers \Bead\Web\Header */
 class HeaderTest extends TestCase
 {
+    private const TestHeaderName = "Content-Type";
 
-    public function testValue()
+    private const TestHeaderValue = "application/json";
+
+    private Header $header;
+
+    protected function setUp(): void
     {
-
+        $this->header = new Header(self::TestHeaderName, self::TestHeaderValue);
     }
 
-    public function testIsValidName()
+    protected function tearDown(): void
     {
-
+        unset($this->header);
     }
 
-    public function testName()
+    /** Provider of valid header names. */
+    public static function validNames(): iterable
     {
-
+        yield "typical" => [self::TestHeaderName,];
+        yield "upper-case" => [strtoupper(self::TestHeaderName),];
+        yield "lower-case" => [strtolower(self::TestHeaderName),];
+        yield "minimal" => ["a",];
+        yield "several-hyphens" => ["X-Bead-Long-Test-Header-Name",];
+        yield "numeric" => ["123"];
     }
 
-    public function testWithName()
+    /** Provider of invalid header names. */
+    public static function invalidNames(): iterable
     {
-
+        yield "empty" => [""];
+        yield "whitespace" => ["  "];
+        yield "leading-whitespace" => [" content type"];
+        yield "trailing-whitespace" => ["content-type  "];
+        yield "surrounding-whitespace" => ["  content-type "];
+        yield "internal-whitespace" => ["content type"];
+        yield "invalid-characters" => ["\x10\x20\x30\x40\x50\x60\x70\x80\x90\xa0\xb0\xc0\xd0\xe0\xf0"];
     }
 
-    public function testWithValue()
+    /**
+     * Ensure valid names are detected as such.
+     * @dataProvider validNames
+     */
+    public function testIsValidName1(string $name): void
     {
-
+        self::assertTrue(Header::isValidName($name));
     }
 
-    public function testLine()
+    /**
+     * Ensure invalid names are detected as such.
+     * @dataProvider invalidNames
+     */
+    public function testIsValidName2(string $name): void
     {
+        self::assertFalse(Header::isValidName($name));
+    }
 
+    /** Ensure we can retrieve the correct name. */
+    public function testName1(): void
+    {
+        self::assertSame(strtolower(self::TestHeaderName), strtolower($this->header->name()));
+    }
+
+    /** Ensure withName() does not return the same instance. */
+    public function testWithName1(): void
+    {
+        self::assertNotSame($this->header, $this->header->withName("Content-Transfer-Encoding"));
+    }
+
+    /** Ensure withName() does not mutate the original. */
+    public function testWithName2(): void
+    {
+        $this->header->withName("Content-Transfer-Encoding");
+        self::assertSame(strtolower(self::TestHeaderName), strtolower($this->header->name()));
+    }
+
+    /** Ensure withName() provides a Header with the new name. */
+    public function testWithName3(): void
+    {
+        $header = $this->header->withName("Content-Transfer-Encoding");
+        self::assertSame("content-transfer-encoding", strtolower($header->name()));
+    }
+
+    /**
+     * Ensure withName() throws with an invalid name.
+     * @dataProvider invalidNames
+     */
+    public function testWithName4(string $name): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Expected valid header name, found \"{$name}\"");
+        $this->header->withName($name);
+    }
+
+    /** Ensure we can retrieve the correct value. */
+    public function testValue1(): void
+    {
+        self::assertSame(self::TestHeaderValue, $this->header->value());
+    }
+
+    /** Ensure withName() does not return the same instance. */
+    public function testWithValue1(): void
+    {
+        self::assertNotSame($this->header, $this->header->withValue("text/html"));
+    }
+
+    /** Ensure withValue() does not mutate the original. */
+    public function testWithValue2(): void
+    {
+        $this->header->withValue("text/html");
+        self::assertSame(strtolower(self::TestHeaderValue), $this->header->Value());
+    }
+
+    /** Ensure withValue() provides a Header with the new value. */
+    public function testWithValue3(): void
+    {
+        $header = $this->header->withValue("text/html");
+        self::assertSame("text/html", $header->Value());
+    }
+
+    /** Ensure the header line is generated correctly. */
+    public function testLine1(): void
+    {
+        self::assertSame("content-type: application/json", $this->header->line());
     }
 }

--- a/test/Web/HeaderTest.php
+++ b/test/Web/HeaderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BeadTests\Web;
+
+use Bead\Web\Header;
+use PHPUnit\Framework\TestCase;
+
+/** TODO implement. */
+class HeaderTest extends TestCase
+{
+
+    public function testValue()
+    {
+
+    }
+
+    public function testIsValidName()
+    {
+
+    }
+
+    public function testName()
+    {
+
+    }
+
+    public function testWithName()
+    {
+
+    }
+
+    public function testWithValue()
+    {
+
+    }
+
+    public function testLine()
+    {
+
+    }
+}

--- a/test/Web/Responses/NaivelySendsContentTest.php
+++ b/test/Web/Responses/NaivelySendsContentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BeadTests\Web\Responses;
 
+use Bead\Web\Header;
 use Bead\Web\Responses\HasDefaultReasonPhrase;
 use Bead\Web\Responses\NaivelySendsContent;
 use BeadTests\Framework\TestCase;
@@ -39,7 +40,15 @@ final class NaivelySendsContentTest extends TestCase
 
             public function headers(): array
             {
-                return NaivelySendsContentTest::TestHeaders;
+                $headers = NaivelySendsContentTest::TestHeaders;
+
+                array_walk(
+                    $headers,
+                    static fn (string &$value, string $key) => $value = new Header($key, $value),
+                    NaivelySendsContentTest::TestHeaders,
+                );
+
+                return $headers;
             }
 
             public function contentType(): string
@@ -64,13 +73,18 @@ final class NaivelySendsContentTest extends TestCase
         );
 
         $expectedHeaders[] = "HTTP/1.1 200 OK";
-        $expectedHeaders[] = "content-type: " . self::TestContentType;
+        $expectedHeaders[] = "Content-Type: " . self::TestContentType;
         $test = $this;
 
         $this->mockFunction(
             "header",
             function (string $header, bool $replace = true) use (&$expectedHeaders, $test) {
-                $test->assertTrue($replace);
+                if (str_starts_with($header, "Content-Type:") || str_starts_with($header, "HTTP/1.1")) {
+                    $test->assertTrue($replace);
+                } else {
+                    $test->assertFalse($replace);
+                }
+
                 $idx = array_search($header, $expectedHeaders);
                 $test->assertIsInt($idx, "Unexpected header '{$header}' generated.");
                 array_splice($expectedHeaders, $idx, 1);

--- a/test/Web/Responses/NaivelySendsContentTest.php
+++ b/test/Web/Responses/NaivelySendsContentTest.php
@@ -44,7 +44,7 @@ final class NaivelySendsContentTest extends TestCase
 
                 array_walk(
                     $headers,
-                    static fn (string &$value, string $key) => $value = new Header($key, $value),
+                    static fn (string & $value, string $key) => $value = new Header($key, $value),
                     NaivelySendsContentTest::TestHeaders,
                 );
 

--- a/test/Web/Responses/NaivelySendsContentTest.php
+++ b/test/Web/Responses/NaivelySendsContentTest.php
@@ -42,11 +42,7 @@ final class NaivelySendsContentTest extends TestCase
             {
                 $headers = NaivelySendsContentTest::TestHeaders;
 
-                array_walk(
-                    $headers,
-                    static fn (string & $value, string $key) => $value = new Header($key, $value),
-                    NaivelySendsContentTest::TestHeaders,
-                );
+                array_walk($headers, static fn (string & $value, string $key) => $value = new Header($key, $value));
 
                 return $headers;
             }

--- a/test/Web/Responses/RedirectResponseTest.php
+++ b/test/Web/Responses/RedirectResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace BeadTests\Web\Responses;
 
+use Bead\Web\Header;
 use Bead\Web\Responses\RedirectResponse;
 use BeadTests\Framework\TestCase;
 
@@ -41,7 +42,7 @@ class RedirectResponseTest extends TestCase
     /** Ensure we get the expected redirect location header. */
     public function testHeaders1(): void
     {
-        self::assertEquals(["location" => "/redirect"], $this->response->headers());
+        self::assertEquals([new Header("location", "/redirect")], $this->response->headers());
     }
 
     /** Ensure we can set the redirect URL. */
@@ -59,7 +60,7 @@ class RedirectResponseTest extends TestCase
 
         $expectedHeaders = [
             "location: /redirect",
-            "content-type: ",
+            "Content-Type: ",
         ];
 
         $httpResponseCode = function (int $statusCode) use ($response): void {
@@ -69,7 +70,12 @@ class RedirectResponseTest extends TestCase
         $header = function (string $header, bool $replace) use (&$expectedHeaders): void {
             $expected = array_shift($expectedHeaders);
             TestCase::assertEquals($expected, $header);
-            TestCase::assertTrue($replace);
+
+            if (str_starts_with($header, "Content-Type:")) {
+                TestCase::assertTrue($replace);
+            } else {
+                TestCase::assertFalse($replace);
+            }
         };
 
         $this->mockFunction("http_response_code", $httpResponseCode);

--- a/test/Web/Responses/SendsHeadersTest.php
+++ b/test/Web/Responses/SendsHeadersTest.php
@@ -31,7 +31,7 @@ final class SendsHeadersTest extends TestCase
             public function headers(): array
             {
                 $headers = SendsHeadersTest::TestHeaders;
-                array_walk($headers, static fn (string &$value, string $key) => $value = new Header($key, $value));
+                array_walk($headers, static fn (string & $value, string $key) => $value = new Header($key, $value));
                 return $headers;
             }
         };

--- a/test/Web/Responses/SendsHeadersTest.php
+++ b/test/Web/Responses/SendsHeadersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BeadTests\Web\Responses;
 
 use Bead\Testing\XRay;
+use Bead\Web\Header;
 use Bead\Web\Responses\SendsHeaders;
 use BeadTests\Framework\TestCase;
 
@@ -29,7 +30,9 @@ final class SendsHeadersTest extends TestCase
 
             public function headers(): array
             {
-                return SendsHeadersTest::TestHeaders;
+                $headers = SendsHeadersTest::TestHeaders;
+                array_walk($headers, static fn (string &$value, string $key) => $value = new Header($key, $value));
+                return $headers;
             }
         };
     }
@@ -43,13 +46,18 @@ final class SendsHeadersTest extends TestCase
             array_values(self::TestHeaders)
         );
 
-        $expectedHeaders[] = "content-type: text/plain";
+        $expectedHeaders[] = "Content-Type: text/plain";
         $test = $this;
 
         $this->mockFunction(
             "header",
             function (string $header, bool $replace) use (&$expectedHeaders, $test) {
-                $test->assertTrue($replace);
+                if (str_starts_with($header, "Content-Type")) {
+                    $test->assertTrue($replace);
+                } else {
+                    $test->assertFalse($replace);
+                }
+
                 $idx = array_search($header, $expectedHeaders);
                 $test->assertIsInt($idx, "Unexpected header '{$header}' generated.");
                 array_splice($expectedHeaders, $idx, 1);


### PR DESCRIPTION
Adds the new contract `Web\Header` as an abstract representation of a HTTP header, along with an implementing immutable class `Web\Header`. The `Web\Response` contract type-hints the `Header` contract as the return type for the `headers()` method. The HTTP response classes, their traits, and the HTTP `Request` class use the new class internally to represent headers.