### PR TITLE
BEAD-245 Add attr() function and test.

### DIFF
--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -140,6 +140,21 @@ function snakeToCamel(string $str, ?string $encoding = null): string
 }
 
 /**
+ * Escape some content for inclusion as an attribute value in the page.
+ * *
+ * * Single ' and double " quotes are escaped to &amp;apos; and &amp;quot; respectively. The content provided must
+ * * be UTF-8 encoded; the returned, escaped, content will be UTF-8 encoded too.
+ * *
+ * * @param $str string The content to escape.
+ * *
+ * * @return string The escaped content.
+ */
+function attr(string $str)
+{
+    return str_replace(["'", "\"",], ["&apos;", "&quot;",], $str);
+}
+
+/**
  * Escape some content for inclusion in the page.
  *
  * Content is escaped with all available HTML5 entities. The content provided must be UTF-8 encoded, and the returned,

--- a/src/Helpers/view-globals.php
+++ b/src/Helpers/view-globals.php
@@ -7,6 +7,7 @@
 namespace
 {
 
+    use function Bead\Helpers\Str\attr as namespacedAttr;
     use function Bead\Helpers\Str\html as namespacedHtml;
     use function Bead\Helpers\I18n\tr as namespacedTr;
 
@@ -14,9 +15,9 @@ namespace
         /**
          * Escape some content for inclusion in the page.
          *
-         * Any characters in the string that have syntactic meaning in HTML are escaped such that they will be interpreted by
-         * the user agent as a normal text character rather than something meaningful in HTML. The content provided must be
-         * UTF-8 encoded, and the returned, escaped, content will be UTF-8 encoded too.
+         * Any characters in the string that have syntactic meaning in HTML are escaped such that they will be
+         * interpreted by the user agent as a normal text character rather than something meaningful in HTML. The
+         * content provided must be UTF-8 encoded; the returned, escaped, content will be UTF-8 encoded too.
          *
          * @param $str string The content to escape.
          *
@@ -25,6 +26,23 @@ namespace
         function html(string $str): string
         {
             return namespacedHtml($str);
+        }
+    }
+
+    if (!function_exists("attr")) {
+        /**
+         * Escape some content for inclusion as an attribute value in the page.
+         *
+         * Single ' and double " quotes are escaped to &amp;apos; and &amp;quot; respectively. The content provided must
+         * be UTF-8 encoded; the returned, escaped, content will be UTF-8 encoded too.
+         *
+         * @param $str string The content to escape.
+         *
+         * @return string The escaped content.
+         */
+        function attr(string $str): string
+        {
+            return namespacedAttr($str);
         }
     }
 

--- a/test/Helpers/StrTest.php
+++ b/test/Helpers/StrTest.php
@@ -10,13 +10,14 @@ use Exception;
 use RuntimeException;
 use TypeError;
 
+use function Bead\Helpers\Str\attr;
+use function Bead\Helpers\Str\build;
 use function Bead\Helpers\Str\camelToSnake;
+use function Bead\Helpers\Str\html;
+use function Bead\Helpers\Str\random;
 use function Bead\Helpers\Str\scrub;
 use function Bead\Helpers\Str\snakeToCamel;
-use function Bead\Helpers\Str\html;
-use function Bead\Helpers\Str\build;
 use function Bead\Helpers\Str\toCodePoints;
-use function Bead\Helpers\Str\random;
 use function range;
 use function strlen;
 use function strspn;
@@ -133,6 +134,37 @@ final class StrTest extends TestCase
         }
 
         $actual = snakeToCamel($str, $encoding);
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test data for testAttr.
+     *
+     * @return iterable The test data.
+     */
+    public function dataForTestAttr(): iterable
+    {
+        yield from [
+            "typicalNoEscaping" => ["foo", "foo",],
+            "bothTypesOfQuotes" => ["\"''\"", "&quot;&apos;&apos;&quot;",],
+            "ampersand-not-escaped" => ["a \"quoted\" & unquoted value", "a &quot;quoted&quot; & unquoted value",],
+        ];
+    }
+
+    /**
+     * @dataProvider dataForTestAttr
+     *
+     * @param mixed $raw The content to escape.
+     * @param string $expected The expected escaped content.
+     * @param string|null $exceptionClass The type of exception expected, if any.
+     */
+    public function testAttr(mixed $raw, string $expected, ?string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $actual = attr($raw);
         self::assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
Adds an attr() helper function to avoid having to fully HTML escape content intended for use in HTML element attributes.