### PR TITLE
BEAD-167 Handle errors loading config more gracefully

### DIFF
--- a/src/Core/ErrorHandler.php
+++ b/src/Core/ErrorHandler.php
@@ -3,6 +3,7 @@
 namespace Bead\Core;
 
 use Bead\Contracts\ErrorHandler as ErrorHandlerContract;
+use Bead\Contracts\Logger;
 use Bead\Contracts\Web\Response;
 use Bead\Exceptions\ViewNotFoundException;
 use Bead\Facades\Log;
@@ -11,6 +12,8 @@ use Bead\Web\Application as WebApplication;
 use Bead\Web\Responses\AbstractResponse;
 use Error;
 use Throwable;
+
+use const STDERR;
 
 /**
  * The default error handler for Applications.
@@ -235,7 +238,13 @@ HTML;
      */
     protected function report(Throwable $error): void
     {
-        Log::critical("Exception in %1[%2]: {$error->getMessage()}", [$error->getFile(), $error->getLine(),]);
+        $app = Application::instance();
+
+        if ($app->serviceIsBound(Logger::class)) {
+            Log::critical("Exception in %1[%2]: {$error->getMessage()}", [$error->getFile(), $error->getLine(),]);
+        } else {
+            fprintf(STDERR, "Exception in %s[%d]: %s", $error->getFile(), $error->getLine(), $error->getMessage());
+        }
     }
 
     /**

--- a/test/Core/ErrorHandlerTest.php
+++ b/test/Core/ErrorHandlerTest.php
@@ -56,7 +56,7 @@ class ErrorHandlerTest extends TestCase
     public function testShouldDisplay1(): void
     {
         $app = $this->mockApplication();
-        $app->shouldReceive("isInDebugMode")->andReturn(true);
+        $app->expects("isInDebugMode")->andReturn(true);
         $handler = new XRay($this->handler);
         self::assertTrue($handler->shouldDisplay(new InvalidArgumentException()));
     }
@@ -65,7 +65,7 @@ class ErrorHandlerTest extends TestCase
     public function testShouldDisplay2(): void
     {
         $app = $this->mockApplication();
-        $app->shouldReceive("isInDebugMode")->andReturn(false);
+        $app->expects("isInDebugMode")->andReturn(false);
         $handler = new XRay($this->handler);
         self::assertFalse($handler->shouldDisplay(new InvalidArgumentException()));
     }
@@ -173,7 +173,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception.", Mockery::on(function (mixed $args) use (&$called): bool {
                 TestCase::assertIsArray($args);
@@ -187,11 +187,15 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication();
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")
+        $app->expects("isInDebugMode")
             ->andReturn(false);
 
         $this->handler->handleException(new InvalidArgumentException("Mock exception."));
@@ -208,7 +212,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$called): bool {
                 TestCase::assertIsArray($args);
@@ -222,11 +226,15 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("sendResponse")->with($error);
+        $app->expects("sendResponse")->with($error);
         $app->shouldNotReceive("isInDebugMode");
 
         $this->handler->handleException($error);
@@ -243,7 +251,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -257,15 +265,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(true);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("views");
+        $app->expects("isInDebugMode")->andReturn(true);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("views");
 
-        $app->shouldReceive("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
+        $app->expects("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
             TestCase::assertInstanceOf(View::class, $response);
             TestCase::assertEquals("errors.exception", $response->name());
             $sendResponseCalled = true;
@@ -287,7 +299,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -301,15 +313,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(true);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("no-views-here");
+        $app->expects("isInDebugMode")->andReturn(true);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("no-views-here");
 
-        $app->shouldReceive("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
+        $app->expects("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
             TestCase::assertNotInstanceOf(View::class, $response);
             TestCase::assertInstanceOf(AbstractResponse::class, $response);
             TestCase::assertEquals(500, $response->statusCode());
@@ -338,7 +354,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -352,15 +368,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(true);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("no-views-here");
+        $app->expects("isInDebugMode")->andReturn(true);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("no-views-here");
 
-        $app->shouldReceive("sendResponse")
+        $app->expects("sendResponse")
             ->once()
             ->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
                 TestCase::assertNotInstanceOf(View::class, $response);
@@ -395,7 +415,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -409,15 +429,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(false);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("views");
+        $app->expects("isInDebugMode")->andReturn(false);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("views");
 
-        $app->shouldReceive("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
+        $app->expects("sendResponse")->with(Mockery::on(function (mixed $response) use (&$sendResponseCalled): bool {
             TestCase::assertInstanceOf(View::class, $response);
             TestCase::assertEquals("errors.error", $response->name());
             $sendResponseCalled = true;
@@ -443,7 +467,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -457,15 +481,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(false);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("views");
+        $app->expects("isInDebugMode")->andReturn(false);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("views");
 
-        $app->shouldReceive("sendResponse")
+        $app->expects("sendResponse")
             ->once()
             ->ordered()
             ->with(Mockery::on(function (mixed $response) use (&$sendFirstResponseCalled): bool {
@@ -476,7 +504,7 @@ class ErrorHandlerTest extends TestCase
             }))
             ->andThrow(new ViewNotFoundException("errors.error", "Exception sending error page."));
 
-        $app->shouldReceive("sendResponse")
+        $app->expects("sendResponse")
             ->once()
             ->ordered()
             ->with(Mockery::on(function (mixed $response) use (&$sendSecondResponseCalled): bool {
@@ -512,7 +540,7 @@ class ErrorHandlerTest extends TestCase
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
             ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args) use (&$reportCalled): bool {
                 TestCase::assertIsArray($args);
@@ -526,15 +554,19 @@ class ErrorHandlerTest extends TestCase
 
         $app = $this->mockApplication(WebApplication::class);
 
-        $app->shouldReceive("get")
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
-        $app->shouldReceive("isInDebugMode")->andReturn(false);
-        $app->shouldReceive("rootDir")->andReturn(__DIR__ . "/files");
-        $app->shouldReceive("config")->with("view.directory", Mockery::any())->andReturn("views");
+        $app->expects("isInDebugMode")->andReturn(false);
+        $app->expects("rootDir")->andReturn(__DIR__ . "/files");
+        $app->expects("config")->with("view.directory", Mockery::any())->andReturn("views");
 
-        $app->shouldReceive("sendResponse")
+        $app->expects("sendResponse")
             ->once()
             ->ordered()
             ->with(Mockery::on(function (mixed $response) use (&$sendFirstResponseCalled): bool {
@@ -545,7 +577,7 @@ class ErrorHandlerTest extends TestCase
             }))
             ->andThrow(new ViewNotFoundException("errors.error", "Exception sending error page."));
 
-        $app->shouldReceive("sendResponse")
+        $app->expects("sendResponse")
             ->once()
             ->ordered()
             ->with(Mockery::on(function (mixed $response) use (&$sendSecondResponseCalled): bool {

--- a/test/Core/ErrorHandlerTest.php
+++ b/test/Core/ErrorHandlerTest.php
@@ -19,6 +19,8 @@ use Mockery;
 use Mockery\MockInterface;
 use RuntimeException;
 
+use const STDERR;
+
 class ErrorHandlerTest extends TestCase
 {
     private ErrorHandler $handler;
@@ -89,18 +91,18 @@ class ErrorHandlerTest extends TestCase
         self::assertEquals("errors.error", $handler->errorPageViewName());
     }
 
-    /** Ensure report() logs the expected message. */
+    /** Ensure report() logs the expected message when a Logger is bound. */
     public function testReport1(): void
     {
-        $error = new InvalidArgumentException("Mock exception.");
+        $error = new InvalidArgumentException("Mock exception");
 
         $log = Mockery::mock(Logger::class);
 
         // it would be foolhardy to set test expectations based on the exception line not changing, so we don't
         // assert to verify the line, just validate it
-        $log->shouldReceive("critical")
+        $log->expects("critical")
             ->once()
-            ->with("Exception in %1[%2]: Mock exception.", Mockery::on(function (mixed $args): bool {
+            ->with("Exception in %1[%2]: Mock exception", Mockery::on(function (mixed $args): bool {
                 TestCase::assertIsArray($args);
                 TestCase::assertIsString($args[0]);
                 TestCase::assertEquals(__FILE__, $args[0]);
@@ -110,13 +112,49 @@ class ErrorHandlerTest extends TestCase
             }));
 
         $app = $this->mockApplication();
-        $app->shouldReceive("get")
+
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(true);
+
+        $app->expects("get")
             ->with(Logger::class)
             ->andReturn($log);
 
         $handler = new XRay($this->handler);
         $handler->report($error);
-        self::markTestAsExternallyVerified();
+    }
+
+    /** Ensure report() outputs the expected message to stderr when no Logger is bound. */
+    public function testReport2(): void
+    {
+        $error = new InvalidArgumentException("Mock exception");
+
+        $app = $this->mockApplication();
+
+        $app->expects("serviceIsBound")
+            ->with(Logger::class)
+            ->andReturn(false);
+
+        $fprintfCalled = false;
+
+        $this->mockFunction("fprintf", static function ($stream, string $template, mixed ... $args) use (&$fprintfCalled) {
+            TestCase::assertFalse($fprintfCalled);
+            TestCase::assertSame(STDERR, $stream);
+            TestCase::assertSame("Exception in %s[%d]: %s", $template);
+            TestCase::assertCount(3, $args);
+            TestCase::assertIsString($args[0]);
+            TestCase::assertEquals(__FILE__, $args[0]);
+            TestCase::assertIsInt($args[1]);
+            TestCase::assertGreaterThanOrEqual(0, $args[1]);
+            TestCase::assertIsString($args[2]);
+            TestCase::assertEquals("Mock exception", $args[2]);
+            $fprintfCalled = true;
+        });
+
+        $handler = new XRay($this->handler);
+        $handler->report($error);
+        self::assertTrue($fprintfCalled);
     }
 
     /** Ensure errors get converted to the expected exceptions. */


### PR DESCRIPTION
Fall back on STDERR in ErrorHandler when there's no Logger bound to the app container.