### PR TITLE
BEAD-257 fix implicitly nullable parameters

### DIFF
--- a/src/Core/ConsoleApplication.php
+++ b/src/Core/ConsoleApplication.php
@@ -539,7 +539,7 @@ abstract class ConsoleApplication extends Application
      * @throws LogicException if the name is not valid or is already in use, the data type is not valid, the description
      *  is empty when trimmed, or the argument is mandatory and optional arguments have already been defined.
      */
-    final protected function addArgument(string $name, string $description, int $type = self::TypeAny, bool $optional = false, string|float|int|array $default = null): void
+    final protected function addArgument(string $name, string $description, int $type = self::TypeAny, bool $optional = false, string|float|int|array|null $default = null): void
     {
         if ("" === trim($description)) {
             throw new LogicException("Expected non-empty argument description, found \"{$description}\"");

--- a/src/Database/SoftDeletes.php
+++ b/src/Database/SoftDeletes.php
@@ -89,7 +89,7 @@ trait SoftDeletes
      *
      * @return string[]
      */
-    protected static function fixedWhereExpressions(string $tableAlias = null): array
+    protected static function fixedWhereExpressions(?string $tableAlias = null): array
     {
         if (static::deletedModelsIncluded()) {
             return [];


### PR DESCRIPTION
A small number of locations use implicit nullability, which is deprecated from PHP 8.4. These are updated to use explicit nullability so that the framework is compatible with PHP 8.4 and later.